### PR TITLE
Compacts code for level 3 file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,15 @@ Level 3 data products will be produced in the standard data pipeline, and the se
 The output format for Level 3 data will be fits files, with individual data products stored in separate extensions that may be read using standard fits software. Direct products from line fits (intensity/velocity/widths) will be viewable and modifiable using XCFIT.
 Specialised routines for displaying secondary derived products such as temperature maps, etc., are not planned at this point.
 
-    ```
-    spice_object->create_l3([window_index] [, approximated_slit=approximated_slit] [, no_fitting=no_fitting] [, no_widget=no_widget] )
-    ```
+```
+spice_object->create_l3([window_index] [, approximated_slit=approximated_slit] [, no_fitting=no_fitting] [, no_widget=no_widget] )
+```
 
 ## For Developers
 
 This repository includes a pre-commit git hook, that updates a specific line of each modified file with the current date and time. The line with this format will be edited:
 ```
-; $Id: 2022-03-18 14:44 CET $
+; $Id: 2022-03-21 12:59 CET $
 ```
 If the file you modified, does not contain this line yet, please add it, preferably append it to the procedure description at the beginning of the file. 
 

--- a/README.md
+++ b/README.md
@@ -173,12 +173,15 @@ Level 3 data products will be produced in the standard data pipeline, and the se
 The output format for Level 3 data will be fits files, with individual data products stored in separate extensions that may be read using standard fits software. Direct products from line fits (intensity/velocity/widths) will be viewable and modifiable using XCFIT.
 Specialised routines for displaying secondary derived products such as temperature maps, etc., are not planned at this point.
 
+    ```
+    spice_object->create_l3([window_index] [, approximated_slit=approximated_slit] [, no_fitting=no_fitting] [, no_widget=no_widget] )
+    ```
 
 ## For Developers
 
 This repository includes a pre-commit git hook, that updates a specific line of each modified file with the current date and time. The line with this format will be edited:
 ```
-; $Id: 2022-03-09 13:26 CET $
+; $Id: 2022-03-18 14:44 CET $
 ```
 If the file you modified, does not contain this line yet, please add it, preferably append it to the procedure description at the beginning of the file. 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/ITA-Solar/solo-spice-ql/wiki
 If you find any bugs, please report them to the PRITS group at the Institute of Theoretical Astrophysics:
 Preferably by raising a new issue here: https://github.com/ITA-Solar/solo-spice-ql/issues
 
-or else by mail to:
+or else by mail to:  
 martin.wiesmann@astro.uio.no  
 s.v.h.haugan@astro.uio.no  
 terje.fredvik@astro.uio.no
@@ -181,7 +181,7 @@ spice_object->create_l3([window_index] [, approximated_slit=approximated_slit] [
 
 This repository includes a pre-commit git hook, that updates a specific line of each modified file with the current date and time. The line with this format will be edited:
 ```
-; $Id: 2022-03-21 12:59 CET $
+; $Id: 2022-03-21 13:02 CET $
 ```
 If the file you modified, does not contain this line yet, please add it, preferably append it to the procedure description at the beginning of the file. 
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-21 11:56 CET $
+; $Id: 2022-03-21 13:49 CET $
 
 
 ;+
@@ -215,11 +215,13 @@ function spice_data::xcfit_block, window_index, approximated_slit=approximated_s
       result = dblarr(n_params+1, sdata[2], sdata[3])
       residual = fltarr(sdata[1], sdata[2], sdata[3])
       include = bytarr(n_components, sdata[2], sdata[3])
+      include[*] = 1
       const = bytarr(n_params, sdata[2], sdata[3])
     endif else if sdata[0] eq 4 then begin
       result = dblarr(n_params+1, sdata[2], sdata[3], sdata[4])
       residual = fltarr(sdata[1], sdata[2], sdata[3], sdata[4])
       include = bytarr(n_components, sdata[2], sdata[3], sdata[4])
+      include[*] = 1
       const = bytarr(n_params, sdata[2], sdata[3], sdata[4])
     endif else begin
       print, 'data cube has wrong number of dimensions.'

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-17 10:50 CET $
+; $Id: 2022-03-17 13:37 CET $
 
 
 ;+
@@ -130,7 +130,7 @@ END
 ;     that contains estimated fit components and the fit.
 ;
 ; KEYWORD PARAMETERS:
-;     window_index : the index of the desired window
+;     window_index : the index of the desired window, default is 0.
 ;     approximated_slit: If set, routine uses a fixed (conservative) value for the slit
 ;                 range, i.e. does not estimate the slit length based on the position of the dumbbells.
 ;     no_fitting: If set, fitting won't be computed. This can still be done manually in xcfit_block.
@@ -208,14 +208,20 @@ END
 ;     Creates a level 3 file from the level 2
 ;
 ; KEYWORD PARAMETERS:
-;     window_index : the index of the desired window
+;     window_index : the index of the desired window, default is all windows
+;     approximated_slit: If set, routine uses a fixed (conservative) value for the slit
+;                 range, i.e. does not estimate the slit length based on the position of the dumbbells.
+;     no_fitting: If set, fitting won't be computed. This can still be done manually in xcfit_block.
+;     no_widget: If set, xcfit_block will not be called
 ;
 ;-
-pro spice_data::create_l3, window_index
+pro spice_data::create_l3, window_index, approximated_slit=approximated_slit, no_fitting=no_fitting, $
+  no_widget=no_widget
   ;Creates level 3 SPICE files with the data of the chosen window(s)
   COMPILE_OPT IDL2
 
-  spice_create_l3, self, window_index
+  spice_create_l3, self, window_index, approximated_slit=approximated_slit, no_fitting=no_fitting, $
+    no_widget=no_widget
 END
 
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-18 14:40 CET $
+; $Id: 2022-03-21 11:26 CET $
 
 
 ;+
@@ -50,7 +50,7 @@
 ;     file : path of a SPICE FITS file.
 ;
 ; OUTPUT:
-;     1 (True) if initialization succeeded, 0 (False) otherwise (not implemented)
+;     1 (True) if initialization succeeded, 0 (False) otherwise
 ;-
 FUNCTION spice_data::init, file
   COMPILE_OPT IDL2
@@ -59,8 +59,8 @@ FUNCTION spice_data::init, file
   self.ccd_size = [1024, 1024]
   IF n_elements(file) EQ 1 THEN BEGIN
     self->read_file, file
-  ENDIF
-  return, 1
+    return, 1
+  ENDIF ELSE return, 0
 END
 
 
@@ -199,6 +199,25 @@ function spice_data::xcfit_block, window_index, approximated_slit=approximated_s
   if ~keyword_set(no_widget) then begin    
     ;SPICE_XCFIT_BLOCK, LAMbda, DAta, WeighTS, FIT, MISS, RESULT, RESIDual, INCLUDE, CONST, ana=ana
     SPICE_XCFIT_BLOCK, ana=ana
+  endif
+
+  if keyword_set(no_fitting) && keyword_set(no_widget) then begin
+    handle_value, ana.result_h, result
+    help, result
+    handle_value, ana.data_h, data
+    help, data
+    handle_value, ana.lambda_h, lambda
+    help, lambda
+    handle_value, ana.residual_h, residual
+    help, residual
+    handle_value, ana.weights_h, weights
+    help, weights
+    handle_value, ana.include_h, include
+    help, include
+    handle_value, ana.const_h, const
+    help, const
+    handle_value, ana.fit_h, fit
+    help, fit
   endif
 
   return, ana

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-21 11:26 CET $
+; $Id: 2022-03-21 11:56 CET $
 
 
 ;+
@@ -202,22 +202,33 @@ function spice_data::xcfit_block, window_index, approximated_slit=approximated_s
   endif
 
   if keyword_set(no_fitting) && keyword_set(no_widget) then begin
-    handle_value, ana.result_h, result
-    help, result
-    handle_value, ana.data_h, data
-    help, data
-    handle_value, ana.lambda_h, lambda
-    help, lambda
-    handle_value, ana.residual_h, residual
-    help, residual
-    handle_value, ana.weights_h, weights
-    help, weights
-    handle_value, ana.include_h, include
-    help, include
-    handle_value, ana.const_h, const
-    help, const
     handle_value, ana.fit_h, fit
-    help, fit
+    n_components = N_TAGS(fit)
+    n_params = 0
+    for itag=0,n_components-1 do begin
+      fit_cur = fit.(itag)
+      n_params = n_params + N_ELEMENTS(fit_cur.param)
+    endfor
+    handle_value, ana.data_h, data
+    sdata = size(data)
+    if sdata[0] eq 3 then begin
+      result = dblarr(n_params+1, sdata[2], sdata[3])
+      residual = fltarr(sdata[1], sdata[2], sdata[3])
+      include = bytarr(n_components, sdata[2], sdata[3])
+      const = bytarr(n_params, sdata[2], sdata[3])
+    endif else if sdata[0] eq 4 then begin
+      result = dblarr(n_params+1, sdata[2], sdata[3], sdata[4])
+      residual = fltarr(sdata[1], sdata[2], sdata[3], sdata[4])
+      include = bytarr(n_components, sdata[2], sdata[3], sdata[4])
+      const = bytarr(n_params, sdata[2], sdata[3], sdata[4])
+    endif else begin
+      print, 'data cube has wrong number of dimensions.'
+      stop
+    endelse
+    handle_value, ana.result_h, result, /no_copy, /set
+    handle_value, ana.residual_h, residual, /no_copy, /set
+    handle_value, ana.include_h, include, /no_copy, /set
+    handle_value, ana.const_h, const, /no_copy, /set
   endif
 
   return, ana

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-17 15:21 CET $
+; $Id: 2022-03-18 14:40 CET $
 
 
 ;+
@@ -1980,6 +1980,7 @@ PRO spice_data::read_file, file
     CASE hdr.BITPIX OF
       16: assocs[iwin] = ptr_new(assoc(file_lun, intarr(hdr.NAXIS1, hdr.NAXIS2, hdr.NAXIS3, hdr.NAXIS4, /NOZERO), position[iwin]))
       -32: assocs[iwin] = ptr_new(assoc(file_lun, fltarr(hdr.NAXIS1, hdr.NAXIS2, hdr.NAXIS3, hdr.NAXIS4, /NOZERO), position[iwin]))
+      -64: assocs[iwin] = ptr_new(assoc(file_lun, dblarr(hdr.NAXIS1, hdr.NAXIS2, hdr.NAXIS3, hdr.NAXIS4, /NOZERO), position[iwin]))
       ELSE: message,'unsupported datatype ' + strtrim(string(hdr.BITPIX), 2)
     ENDCASE
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.  
 ;-
-; $Id: 2022-03-17 13:37 CET $
+; $Id: 2022-03-17 15:21 CET $
 
 
 ;+
@@ -128,9 +128,11 @@ END
 ; Description:
 ;     Calls xcfit_block with the data of the chosen window and returns an analysis structure
 ;     that contains estimated fit components and the fit.
+;     This function is also called by 'create_l3' method, to get the ANA structure, which is
+;     then saved into a level 3 FITS file.
 ;
 ; KEYWORD PARAMETERS:
-;     window_index : the index of the desired window, default is 0.
+;     window_index : The index of the desired window, default is 0.
 ;     approximated_slit: If set, routine uses a fixed (conservative) value for the slit
 ;                 range, i.e. does not estimate the slit length based on the position of the dumbbells.
 ;     no_fitting: If set, fitting won't be computed. This can still be done manually in xcfit_block.
@@ -208,7 +210,7 @@ END
 ;     Creates a level 3 file from the level 2
 ;
 ; KEYWORD PARAMETERS:
-;     window_index : the index of the desired window, default is all windows
+;     window_index : The index of the desired window, default is all windows.
 ;     approximated_slit: If set, routine uses a fixed (conservative) value for the slit
 ;                 range, i.e. does not estimate the slit length based on the position of the dumbbells.
 ;     no_fitting: If set, fitting won't be computed. This can still be done manually in xcfit_block.

--- a/utils/spice_create_l3.pro
+++ b/utils/spice_create_l3.pro
@@ -10,7 +10,8 @@
 ;     Solar Orbiter - SPICE.
 ;
 ; CALLING SEQUENCE:
-;     spice_create_l3, spice_object, window_index
+;     spice_create_l3, spice_object [, window_index] [, approximated_slit=approximated_slit] [, no_fitting=no_fitting]
+;       [, no_widget=no_widget]
 ;
 ; INPUTS:
 ;     spice_object : a SPICE_DATA object.
@@ -40,7 +41,7 @@
 ; HISTORY:
 ;     23-Nov-2021: Martin Wiesmann
 ;-
-; $Id: 2022-03-17 13:37 CET $
+; $Id: 2022-03-21 11:07 CET $
 
 
 pro spice_create_l3, spice_object, window_index, approximated_slit=approximated_slit, no_fitting=no_fitting, $
@@ -69,22 +70,7 @@ pro spice_create_l3, spice_object, window_index, approximated_slit=approximated_
       CONST=CONST, FILENAME_ANA=FILENAME_ANA, DATASOURCE=DATASOURCE, $
       DEFINITION=DEFINITION, MISSING=MISSING, LABEL=LABEL)
 
-    help, headers
-    help, filename_l3
-    help,result
-    help,INPUT_DATA
-    help,lambda
-    help,residual
-    help,weights
-    help,include
-    help,const
-    help,fit
-
-    if iwindow eq 0 then begin
-      file = filepath(filename_l3, /tmp)
-      help,file
-      ;stop
-    endif
+    if iwindow eq 0 then file = filepath(filename_l3, /tmp)
 
     writefits, file, RESULT, *headers[0], append=extension
     writefits, file, INPUT_DATA, *headers[1], /append
@@ -99,8 +85,6 @@ pro spice_create_l3, spice_object, window_index, approximated_slit=approximated_
   endfor ; iwindow=0,N_ELEMENTS(window_index)-1
 
   spice_ingest, file, destination=destination, file_moved=file_moved, files_found=files_found, /force
-  print,files_found
-  print,file_moved
-  print,destination
+  print, 'Level 3 file saved to: ', destination
 
 end


### PR DESCRIPTION
In this merge, I merged the SPICE_DATA method xcfit_block into the create_l3 method to avoid duplication of code. I also added a few new keywords to create_l3 and xcfit_block:
* approximated_slit: This keyword was already there for xcfit_block, added it also to create_l3. @tfredvik Should this be set by default, when creating l3 files?
* no_fitting: If set, cfit_block is not run, i.e. the fitting is not done. Useful for debugging.
* no_widget: If set, xcfit_block is not called after preparing the data, finding the peaks and possibly computing the fit. Useful for the creation of l3 file programmatically, without checking the results manually.

If both 'no_fitting' and 'no_widget' are set, then some of the data cubes are not being set (i.e. result, residual, include, const). So I have to make sure, that those are initialised, so that the FItS file can be saved.

Also updated, the wiki and the README.