### PR TITLE
Renames bintable methods and improves method

### DIFF
--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-05 11:10 CEST $
+; $Id: 2022-05-05 11:14 CEST $
 
 
 ;+
@@ -2086,6 +2086,42 @@ PRO spice_data::read_file, file
 
   ENDFOR ; iwin = 0, self.nwin-1
   
+  self.window_assoc = ptr_new(assocs)
+  self.window_data = ptr_new(ptrarr(self.nwin))
+  self.window_descaled = ptr_new(bytarr(self.nwin))
+  self.window_headers = ptr_new(headers)
+  self.window_headers_string = ptr_new(headers_string)
+  self.window_wcs = ptr_new(wcs)
+  self.slit_y_range = ptr_new(/allocate)
+  
+  self.get_bintable_info
+END
+
+
+;+
+; Description:
+;     Returns the input filename
+;
+; OUTPUT:
+;     string
+;-
+FUNCTION spice_data::get_filename
+  ;returns the input filename
+  COMPILE_OPT IDL2
+
+  return, self.file
+END
+
+
+;+
+; Description:
+;     This methods collects information about the binary table extension(s)
+;     It will not load the data itself. This is done when the user calls the method
+;     spice_data::get_bintable_data(ttypes)
+;-
+FUNCTION spice_data::get_bintable_info
+  COMPILE_OPT IDL2
+
   FXBOPEN, bin_unit, file, self.nwin
   FXBFIND, bin_unit, 'WCSN', WCSN_ind, WCSN, N_FOUND
   WCSN = strtrim(WCSN, 2)
@@ -2136,29 +2172,6 @@ PRO spice_data::read_file, file
     bin_table_columns[i].desc = tdesc[i]
   ENDFOR
 
-  self.window_assoc = ptr_new(assocs)
-  self.window_data = ptr_new(ptrarr(self.nwin))
-  self.window_descaled = ptr_new(bytarr(self.nwin))
-  self.window_headers = ptr_new(headers)
-  self.window_headers_string = ptr_new(headers_string)
-  self.window_wcs = ptr_new(wcs)
-  self.slit_y_range = ptr_new(/allocate)
-  self.bin_table_columns = ptr_new(bin_table_columns)
-END
-
-
-;+
-; Description:
-;     Returns the input filename
-;
-; OUTPUT:
-;     string
-;-
-FUNCTION spice_data::get_filename
-  ;returns the input filename
-  COMPILE_OPT IDL2
-
-  return, self.file
 END
 
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-06 13:26 CEST $
+; $Id: 2022-05-08 21:21 CEST $
 
 
 ;+
@@ -1066,11 +1066,15 @@ END
 ;
 ; OPTIONAL OUTPUT:
 ;     exists : boolean, True if keyword exists
+;     variable_values : array, contains the variable values for this keyword, if this keyword is present
+;                       in the binary table extension 'VARIABLE-KEYWORDS', otherwise !NULL.
+;                       Calls the method spice_data::get_bintable_data with the VALUES_ONLY keyword set.
 ;
 ; OUTPUT:
 ;     returns the keyword value, 'missing_value' or !NULL
 ;-
-FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, exists=exists
+FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, exists=exists, $
+  variable_values=variable_values
   ;Returns the specified keyword from the window, or 'missing_value' if provided, !NULL otherwise
   COMPILE_OPT IDL2
 
@@ -1086,6 +1090,10 @@ FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, e
   ; '-' becomes '_D$'
   temp = strsplit(keyword, '-', count=count, /extract)
   IF count GT 1 THEN keyword = strjoin(temp, '_D$')
+
+  IF ARG_PRESENT(variable_values) THEN BEGIN
+    variable_values = self.get_bintable_data(keyword, /values_only)
+  ENDIF
 
   exists = TAG_EXIST(*(*self.window_headers)[window_index], keyword, index=index)
   IF exists THEN BEGIN

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-05 13:48 CEST $
+; $Id: 2022-05-05 14:03 CEST $
 
 
 ;+
@@ -2186,56 +2186,6 @@ FUNCTION spice_data::get_bintable_info
     bintable_columns[index].ttype = strup(strtrim(column, 2))
     bintable_columns[index].extension = extension
   endforeach
-  
-
-  FXBOPEN, bin_unit, file, self.nwin
-  FXBFIND, bin_unit, 'WCSN', WCSN_ind, WCSN, N_FOUND
-  WCSN = strtrim(WCSN, 2)
-  FXBFIND, bin_unit, 'TFORM', TFORM_ind, TFORM, N_FOUND
-  TFORM = strtrim(TFORM, 2)
-  FXBFIND, bin_unit, 'TTYPE', TTYPE_ind, TTYPE, N_FOUND, comments=comments
-  TTYPE = strtrim(TTYPE, 2)
-  comments = strcompress(strtrim(comments, 2))
-  FXBFIND, bin_unit, 'TDIM', TDIM_ind, TDIM, N_FOUND
-  TDIM = strtrim(TDIM, 2)
-  FXBFIND, bin_unit, 'TUNIT', TUNIT_ind, TUNIT, N_FOUND
-  TUNIT = strtrim(TUNIT, 2)
-  FXBFIND, bin_unit, 'TDMIN', TDMIN_ind, TDMIN, N_FOUND
-  TDMIN = strtrim(TDMIN, 2)
-  FXBFIND, bin_unit, 'TDMAX', TDMAX_ind, TDMAX, N_FOUND
-  TDMAX = strtrim(TDMAX, 2)
-  FXBFIND, bin_unit, 'TDESC', TDESC_ind, TDESC, N_FOUND
-  TDESC = strtrim(TDESC, 2)
-  FXBCLOSE, bin_unit
-
-  bin_table_columns = make_array(self.n_bin_table_columns, value=temp_column)
-  ; Get unit and unit description
-  tunit_temp = tunit
-  tunit_desc = tunit
-  FOR i=0,self.n_bin_table_columns-1 DO BEGIN
-    unit = stregex(comments[i], '\[.*\]', /extract)
-    IF strlen(unit) GE 2 THEN BEGIN
-      tunit_temp[i] = strtrim(strmid(unit, 1, strlen(unit)-2), 2)
-      tunit_desc[i] = strtrim(strmid(comments[i], strlen(unit)+1), 2)
-    ENDIF ELSE BEGIN
-      tunit_temp[i] = ''
-      tunit_desc[i] = comments[i]
-    ENDELSE
-    IF TUNIT[i] EQ '' THEN BEGIN
-      tunit[i] = tunit_temp[i]
-    ENDIF
-
-    bin_table_columns[i].wcsn = wcsn[i]
-    bin_table_columns[i].form = tform[i]
-    bin_table_columns[i].type = ttype[i]
-    bin_table_columns[i].dim = tdim[i]
-    bin_table_columns[i].unit = tunit[i]
-    bin_table_columns[i].unit_desc = tunit_desc[i]
-    bin_table_columns[i].dmin = tdmin[i]
-    bin_table_columns[i].dmax = tdmax[i]
-    bin_table_columns[i].desc = tdesc[i]
-  ENDFOR
-
 END
 
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-06 13:21 CEST $
+; $Id: 2022-05-06 13:26 CEST $
 
 
 ;+
@@ -2001,7 +2001,9 @@ END
 ;+
 ; Description:
 ;     This method returns the content of one or more columns found in the binary extension table.
-;     If the given tag does not exist, the same structure is returned with empty strings.
+;     If the given tag does not exist, the same structure is returned with empty fields, except the
+;     tag 'TTYPE' is populated with the provided ttype. When requesting the data of only one TTYPE,
+;     one can set the keyword VALUES_ONLY to receive the data only as an array, instead of the structure.
 ;
 ; OPTIONAL INPUTS:
 ;     ttypes : one or more column tags to be returned (e.g. 'MIRRPOS'). If not provided, all columns will
@@ -2011,11 +2013,12 @@ END
 ;     array of structure of type:
 ;             {wcsn:'', tform:'', ttype:'', tdim:'', tunit:'', tunit_desc:'', tdmin:'', tdmax:'', tdesc:'', $
 ;               extension:'', values:ptr_new()}
+;     or the data only, i.e. an array of numbers.
 ;
 ; KEYWORDS:
 ;     values_only: If set then only the values in the binary table extension is returned as an array,
 ;                  no the default output structure with metadata. This keyword is ignored if more than
-;                  one TTYPES have been provided.
+;                  one TTYPES have been provided. If the desired TTYPE does not exist, a !NULL is returned.
 ;-
 FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
   ;Returns the content of one or more columns found in the binary extension table.

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-05 14:52 CEST $
+; $Id: 2022-05-06 12:58 CEST $
 
 
 ;+
@@ -2016,18 +2016,20 @@ FUNCTION spice_data::get_bintable_data, ttypes
   ;Returns the content of one or more columns found in the binary extension table.
   COMPILE_OPT IDL2
 
+  IF self.n_bintable_columns EQ 0 THEN BEGIN
+    print, 'No binary table extension with variable keywords in this FITS file.'
+  ENDIF
   IF N_ELEMENTS(ttypes) eq 0 THEN BEGIN
-    ttypes_up = self.get_bintable_ttypes()
-  ENDIF ELSE BEGIN
-    ttypes_up = strup(strtrim(ttypes, 2))
-  ENDELSE
+    ttypes = self.get_bintable_ttypes()
+  ENDIF
+  ttypes_up = strup(strtrim(ttypes, 2))
   temp_column = {wcsn:'', tform:'', ttype:'', tdim:'', tunit:'', tunit_desc:'', tdmin:'', tdmax:'', tdesc:'', $
     extension:'', values:ptr_new()}
   result = make_array(N_ELEMENTS(ttypes_up), value=temp_column)
   file_open = 0
   FOR i=0,N_ELEMENTS(ttypes_up)-1 DO BEGIN
     ind = where((*self.bintable_columns).ttype eq ttypes_up[i], count)
-    IF count GT 0 THEN BEGIN
+    IF count GT 0 && self.n_bintable_columns GT 0 THEN BEGIN
       ind=ind[0]
       
       IF ~ptr_valid((*self.bintable_columns)[ind].values) THEN BEGIN
@@ -2068,9 +2070,9 @@ FUNCTION spice_data::get_bintable_data, ttypes
       ENDIF ; ~ptr_valid((*self.bintable_columns)[ind].values)
 
       result[i] = (*self.bintable_columns)[ind]
-    ENDIF ELSE BEGIN ; count GT 0
+    ENDIF ELSE BEGIN ; count GT 0 && self.n_bintable_columns GT 0
       result[i].ttype = ttypes[i]
-    ENDELSE ; count GT 0
+    ENDELSE ; count GT 0 && self.n_bintable_columns GT 0
   ENDFOR ; i=0,N_ELEMENTS(ttypes_up)-1
   IF file_open THEN FXBCLOSE, unit
   return, result

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-06 12:58 CEST $
+; $Id: 2022-05-06 13:21 CEST $
 
 
 ;+
@@ -2011,8 +2011,13 @@ END
 ;     array of structure of type:
 ;             {wcsn:'', tform:'', ttype:'', tdim:'', tunit:'', tunit_desc:'', tdmin:'', tdmax:'', tdesc:'', $
 ;               extension:'', values:ptr_new()}
+;
+; KEYWORDS:
+;     values_only: If set then only the values in the binary table extension is returned as an array,
+;                  no the default output structure with metadata. This keyword is ignored if more than
+;                  one TTYPES have been provided.
 ;-
-FUNCTION spice_data::get_bintable_data, ttypes
+FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
   ;Returns the content of one or more columns found in the binary extension table.
   COMPILE_OPT IDL2
 
@@ -2068,13 +2073,23 @@ FUNCTION spice_data::get_bintable_data, ttypes
         (*self.bintable_columns)[ind].tunit_desc = tunit_desc
         
       ENDIF ; ~ptr_valid((*self.bintable_columns)[ind].values)
-
       result[i] = (*self.bintable_columns)[ind]
+      
     ENDIF ELSE BEGIN ; count GT 0 && self.n_bintable_columns GT 0
       result[i].ttype = ttypes[i]
+      
     ENDELSE ; count GT 0 && self.n_bintable_columns GT 0
   ENDFOR ; i=0,N_ELEMENTS(ttypes_up)-1
   IF file_open THEN FXBCLOSE, unit
+  IF keyword_set(values_only) && N_ELEMENTS(ttypes) EQ 1 THEN BEGIN
+    IF ptr_valid(result.values) THEN BEGIN
+      result_temp = *result.values
+      ptr_free, result.values
+      result = result_temp
+    ENDIF ELSE BEGIN
+      result = !NULL
+    ENDELSE
+  ENDIF
   return, result
 END
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-04 13:46 CEST $
+; $Id: 2022-05-05 11:10 CEST $
 
 
 ;+
@@ -1980,7 +1980,7 @@ END
 ; OUTPUT:
 ;     string array
 ;-
-FUNCTION spice_data::get_bin_column_tags
+FUNCTION spice_data::get_bintable_ttypes
   ;Returns a list of column tags that can be found in the binary extension table.
   COMPILE_OPT IDL2
 
@@ -2001,7 +2001,7 @@ END
 ;     array of structure of type:
 ;             {wcsn:'', form:'', type:'', dim:'', unit:'', unit_desc:'', dmin:'', dmax:'', desc:'', values:ptr_new()}
 ;-
-FUNCTION spice_data::get_bin_column_data, tags
+FUNCTION spice_data::get_bintable_data, ttypes
   ;Returns the content of one or more columns found in the binary extension table.
   COMPILE_OPT IDL2
 

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-05 11:32 CEST $
+; $Id: 2022-05-05 11:45 CEST $
 
 
 ;+
@@ -86,10 +86,10 @@ pro spice_data::close
   ptr_free, self.window_descaled
   ptr_free, self.window_data
   ptr_free, self.slit_y_range
-  for i=0,self.n_bin_table_columns-1 do begin
-    if ptr_valid((*self.bin_table_columns)[i].values) then ptr_free, (*self.bin_table_columns)[i].values
-  endfor
-  ptr_free, self.bin_table_columns
+  ;for i=0,self.n_bin_table_columns-1 do begin
+  ;  if ptr_valid((*self.bin_table_columns)[i].values) then ptr_free, (*self.bin_table_columns)[i].values
+  ;endfor
+  ;ptr_free, self.bin_table_columns
   IF self.file_lun GE 100 && self.file_lun LE 128 THEN free_lun, self.file_lun
   self.dumbbells = [-1, -1]
   self.nwin = 0
@@ -1104,7 +1104,7 @@ END
 ;     get_header_keyword instead replaces this method. See there for documentation
 ;-
 FUNCTION spice_data::get_header_info, keyword, window_index, missing_value, exists=exists
-  return, self.get_header_keyword, keyword, window_index, missing_value, exists=exists
+  return, self.get_header_keyword(keyword, window_index, missing_value, exists=exists)
 END
 
 
@@ -2104,7 +2104,7 @@ PRO spice_data::read_file, file
   self.window_wcs = ptr_new(wcs)
   self.slit_y_range = ptr_new(/allocate)
   
-  self.get_bintable_info
+  ;self.get_bintable_info
 END
 
 
@@ -2131,6 +2131,8 @@ END
 ;-
 FUNCTION spice_data::get_bintable_info
   COMPILE_OPT IDL2
+  
+  var_keys = self.get_header_keyword('VAR_KEYS', 0, '')
 
   FXBOPEN, bin_unit, file, self.nwin
   FXBFIND, bin_unit, 'WCSN', WCSN_ind, WCSN, N_FOUND

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-11 14:31 CEST $
+; $Id: 2022-05-13 13:47 CEST $
 
 
 ;+
@@ -1070,13 +1070,17 @@ END
 ;     exists : boolean, Set this to a named variable. This variable will be set to 1, if the keyword exists, 0 otherwise.
 ;     variable_values : array, contains the variable values for this keyword, if this keyword is present
 ;                       in the binary table extension 'VARIABLE-KEYWORDS', otherwise !NULL.
-;                       Calls the method spice_data::get_bintable_data with the VALUES_ONLY keyword set.
+;                       Calls the method spice_data::get_bintable_data with the VALUES_ONLY keyword.
+;
+; KEYWORDS:
+;     values_only: If set then only the values in the binary table extension are returned to VARIABLE_VALUES as an array,
+;                  instead of the default output structure with metadata.
 ;
 ; OUTPUT:
 ;     Returns either the keyword value, the MISSING_VALUE or !NULL.
 ;-
 FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, exists=exists, $
-  variable_values=variable_values
+  variable_values=variable_values, values_only=values_only
   ;Returns the specified keyword from the window, or 'missing_value' if provided, !NULL otherwise
   COMPILE_OPT IDL2
 
@@ -1094,7 +1098,7 @@ FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, e
   IF count GT 1 THEN keyword = strjoin(temp, '_D$')
 
   IF ARG_PRESENT(variable_values) THEN BEGIN
-    variable_values = self.get_bintable_data(keyword, /values_only)
+    variable_values = self.get_bintable_data(keyword, values_only=values_only)
   ENDIF
 
   exists = TAG_EXIST(*(*self.window_headers)[window_index], keyword, index=index)
@@ -2026,8 +2030,8 @@ END
 ;     or the data only, i.e. an array of numbers.
 ;
 ; KEYWORDS:
-;     values_only: If set then only the values in the binary table extension is returned as an array,
-;                  not the default output structure with metadata. This keyword is ignored if more than
+;     values_only: If set then only the values in the binary table extension are returned as an array,
+;                  instead of the default output structure with metadata. This keyword is ignored if more than
 ;                  one TTYPES have been provided. If the desired TTYPE does not exist, a !NULL is returned.
 ;-
 FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
@@ -2098,9 +2102,7 @@ FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
   
   IF keyword_set(values_only) && N_ELEMENTS(ttypes) EQ 1 THEN BEGIN
     IF ptr_valid(result.values) THEN BEGIN
-      result_temp = *result.values
-      ptr_free, result.values
-      result = result_temp
+      result = *result.values
     ENDIF ELSE BEGIN
       result = !NULL
     ENDELSE

--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-05-08 21:21 CEST $
+; $Id: 2022-05-11 14:31 CEST $
 
 
 ;+
@@ -1053,25 +1053,27 @@ END
 
 ;+
 ; Description:
-;     Returns the specified keyword from the given window, if the keyword
-;     does not exist 'missing_value' is returned if it is provided, !NULL otherwise.
+;     This method returns the specified keyword from the given window, if the keyword does not exist 
+;     'missing_value' is returned if it is provided, !NULL otherwise. This method can also return 
+;     the variable values of a keyword, if it is available in the binary table extension. 
+;     See keyword VARIABLE_VALUES.
 ;
 ; INPUTS:
-;     keyword : string, the header keyword to be returned
-;     window_index : the index of the window this keyword belongs to
+;     keyword : string, The header keyword for which the value should be returned.
+;     window_index : The index of the window this keyword belongs to.
 ;
 ; OPTIONAL INPUTS:
 ;     missing_value : the value that should be returned, if the keyword does not exist
 ;                     if this is not provided !NULL is returned
 ;
 ; OPTIONAL OUTPUT:
-;     exists : boolean, True if keyword exists
+;     exists : boolean, Set this to a named variable. This variable will be set to 1, if the keyword exists, 0 otherwise.
 ;     variable_values : array, contains the variable values for this keyword, if this keyword is present
 ;                       in the binary table extension 'VARIABLE-KEYWORDS', otherwise !NULL.
 ;                       Calls the method spice_data::get_bintable_data with the VALUES_ONLY keyword set.
 ;
 ; OUTPUT:
-;     returns the keyword value, 'missing_value' or !NULL
+;     Returns either the keyword value, the MISSING_VALUE or !NULL.
 ;-
 FUNCTION spice_data::get_header_keyword, keyword, window_index, missing_value, exists=exists, $
   variable_values=variable_values
@@ -2025,7 +2027,7 @@ END
 ;
 ; KEYWORDS:
 ;     values_only: If set then only the values in the binary table extension is returned as an array,
-;                  no the default output structure with metadata. This keyword is ignored if more than
+;                  not the default output structure with metadata. This keyword is ignored if more than
 ;                  one TTYPES have been provided. If the desired TTYPE does not exist, a !NULL is returned.
 ;-
 FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
@@ -2091,7 +2093,9 @@ FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
       
     ENDELSE ; count GT 0 && self.n_bintable_columns GT 0
   ENDFOR ; i=0,N_ELEMENTS(ttypes_up)-1
+  
   IF file_open THEN FXBCLOSE, unit
+  
   IF keyword_set(values_only) && N_ELEMENTS(ttypes) EQ 1 THEN BEGIN
     IF ptr_valid(result.values) THEN BEGIN
       result_temp = *result.values
@@ -2101,6 +2105,7 @@ FUNCTION spice_data::get_bintable_data, ttypes, values_only=values_only
       result = !NULL
     ENDELSE
   ENDIF
+  
   return, result
 END
 


### PR DESCRIPTION
Renamed methods:
- **get_bintable_ttypes()**: Returns string array with available ttypes in all binary table extensions. Values taken from header keyword `VAR_KEYS`. (previously _get_bin_column_tags_)
- **get_bintable_data(ttypes)**: Returns data of given ttypes, including header keyword infos (e.g. units). (previously _get_bin_column_data_)

Returned structure tags have now 't' in front again, i.e.:
```
{wcsn:'', tform:'', ttype:'', tdim:'', tunit:'', tunit_desc:'', tdmin:'', tdmax:'', tdesc:'', $
    extension:'', values:ptr_new()}
```

When initialising a SPICE object, only the VAR_KEYS keyword is read in and saved. The binary extension table is only read upon request by the user, when he calls get_bintable_data.

Unrelated change:
Renamed method `get_header_info` to `get_header_keyword`. This seemed more understable. get_header_info is still there, but calls internally get_header_keyword. There might be users who use this method.

Related change:
Added new keyword to method `get_header_info`, `variable_values`. If set to a named variable, this will return the values from the binary table extension. Calls in the background `get_bintable_data(keyword, /values_only)`.