### PR TITLE
Adds toggle switches to QL software to change between masked/unmasked non-slit pixels

### DIFF
--- a/objects/spice_data__define.pro
+++ b/objects/spice_data__define.pro
@@ -39,7 +39,7 @@
 ;                  SLIT_ONLY keyword is set when calling ::get_window_data.
 ;                  * The SLIT_ONLY keyword is set when xcfit_block is called.
 ;-
-; $Id: 2022-09-12 14:17 CEST $
+; $Id: 2022-09-22 11:55 CEST $
 
 
 ;+
@@ -1008,15 +1008,13 @@ FUNCTION spice_data::get_window_data, window_index, noscale=noscale, $
     data = *(*self.window_data)[window_index]
   ENDIF ELSE BEGIN
     data = readfits(self.get_filename(), hdr, noscale=noscale, ext=window_index)
-    (*self.window_descaled)[window_index] = descaled
-    (*self.window_masked)[window_index] = masked
-    IF ptr_valid((*self.window_data)[window_index]) THEN ptr_free, (*self.window_data)[window_index]
-    (*self.window_data)[window_index] = ptr_new(data)
     IF ~keyword_set(no_masking) THEN BEGIN
       data = self.mask_regions_outside_slit(data, window_index, approximated_slit = approximated_slit, debug_plot = debug_plot)
-      IF ptr_valid((*self.window_data)[window_index]) THEN ptr_free, (*self.window_data)[window_index]
-      (*self.window_data)[window_index] = ptr_new(data)
     ENDIF
+    IF ptr_valid((*self.window_data)[window_index]) THEN ptr_free, (*self.window_data)[window_index]
+    (*self.window_data)[window_index] = ptr_new(data)
+    (*self.window_descaled)[window_index] = descaled
+    (*self.window_masked)[window_index] = masked
   ENDELSE
   return, data
 END

--- a/quicklook/spice_raster_browser/spice_browser_base_event.pro
+++ b/quicklook/spice_raster_browser/spice_browser_base_event.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-08-29 14:18 CEST $
+; $Id: 2022-09-20 15:06 CEST $
 
 
 PRO spice_browser_base_event, event
@@ -417,22 +417,22 @@ PRO spice_browser_base_event, event
     ;
     ; the following replaces the sji_d tag with the new sji object
     ;
-    
-;    sji_file=state.wid_data.sji_file[event.index]
-;    state_temp=rem_tag(state,'sji_d')
-;    state=0
-;    state=add_tag(state_temp,iris_sji(sji_file),'sji_d')
-;    state_temp=0
-;    ;
-;    ; For the droplist with the number of frames options, I need to re-do
-;    ; the options since different channels may have different numbers of frames.
-;    sji_droplist_options=spice_browser_sji_frame_options(state, $
-;      default_option=default_option)
-;    state.wid_data.sji_mov_frames=fix(sji_droplist_options[default_option])
-;
-;    ;; sji_nexp=state.sji_d->getnexp(0)
-;    ;; sji_droplist_value=[trim(1),trim(sji_nexp)]
-;    widget_control,state.sji_frames_droplist,set_value=sji_droplist_options
+
+    ;    sji_file=state.wid_data.sji_file[event.index]
+    ;    state_temp=rem_tag(state,'sji_d')
+    ;    state=0
+    ;    state=add_tag(state_temp,iris_sji(sji_file),'sji_d')
+    ;    state_temp=0
+    ;    ;
+    ;    ; For the droplist with the number of frames options, I need to re-do
+    ;    ; the options since different channels may have different numbers of frames.
+    ;    sji_droplist_options=spice_browser_sji_frame_options(state, $
+    ;      default_option=default_option)
+    ;    state.wid_data.sji_mov_frames=fix(sji_droplist_options[default_option])
+    ;
+    ;    ;; sji_nexp=state.sji_d->getnexp(0)
+    ;    ;; sji_droplist_value=[trim(1),trim(sji_nexp)]
+    ;    widget_control,state.sji_frames_droplist,set_value=sji_droplist_options
     ;
     ;
     widget_control,state.spice_browser_base,set_uval=state
@@ -786,6 +786,23 @@ PRO spice_browser_base_event, event
       ENDIF
     END
 
+    state.mask_butt: BEGIN
+      meta=spice_browser_get_metadata(state.data)
+      spice_browser_update_widdata,state,meta
+      spice_browser_update_info,state
+      widget_control,state.spice_browser_base,set_uvalue=state
+      widget_control,state.exp_slider,set_value=xpix_chunk
+      n=state.wid_data.n_plot_window
+      FOR i=0,n-1 DO BEGIN
+        spice_browser_update_image,state,i
+        spice_browser_update_spectrum,state,i
+        spice_browser_plot_image,state,i
+        spice_browser_plot_spectrum,state,i
+      ENDFOR
+      IF state.wid_data.sji EQ 1 THEN spice_browser_plot_sji, state
+      spice_browser_goes_plot,state
+    END
+
     ;
     ; Where nexp_prp>1, allows specific exp. time to be selected.
     ;
@@ -811,55 +828,55 @@ PRO spice_browser_base_event, event
     END
 
 
-;    state.sji_movie_butt: BEGIN
-;      ;
-;      ; This is the 'Show Movie' button and it sends the movie parameters to
-;      ; ximovie
-;      ;
-;
-;      ; A quirk of ximovie is that it will crash if pos is set to the
-;      ; full size of the SJI images. I thus check the status of im_zoom:
-;      ; if no zoom (i.e., full image) then pos is not defined.
-;      ;
-;      im_zoom=state.wid_data.im_zoom
-;      IF im_zoom NE 0 THEN pos=[state.wid_data.sji_xrange,state.wid_data.sji_yrange]
-;
-;      widget_control,state.min_text_sji,get_value=sji_min
-;      widget_control,state.max_text_sji,get_value=sji_max
-;
-;      i=state.wid_data.sji_frame
-;      n=state.wid_data.sji_nframe
-;      d=state.wid_data.sji_mov_frames
-;
-;      IF d EQ n THEN BEGIN
-;        first_im=0
-;        last_im=n-1
-;      ENDIF ELSE BEGIN
-;        d2=fix((fix(d)-1)/2.)
-;        first_im=max([0,i-d2])
-;        last_im=min([i+d2,n-1])
-;      ENDELSE
-;
-;      state.sji_d->ximovie,pos=pos, log=state.wid_data.linlog, $
-;        first_im=first_im,last_im=last_im,start_im=i
-;    END
-;
-;    state.sji_frames_droplist: BEGIN
-;      widget_control,state.sji_frames_droplist,get_value=value
-;      result=value[event.index]
-;      IF trim(result) EQ 'all' THEN sji_mov_frames=state.wid_data.sji_nframe $
-;      ELSE sji_mov_frames=fix(result)
-;      state.wid_data.sji_mov_frames=sji_mov_frames
-;      ;
-;      ; Update the movie duration widget
-;      ;
-;      sji_mov_dur=(sji_mov_frames*state.wid_data.sji_cadence)/60.
-;      sji_mov_dur_txt=trim(string(sji_mov_dur,format='(f7.1)'))
-;      sji_dur_txt='Movie duration: '+sji_mov_dur_txt+' mins (approx)'
-;      widget_control,state.sji_dur_text,set_val=sji_dur_txt
-;      ;
-;      widget_control,state.spice_browser_base,set_uval=state
-;    END
+    ;    state.sji_movie_butt: BEGIN
+    ;      ;
+    ;      ; This is the 'Show Movie' button and it sends the movie parameters to
+    ;      ; ximovie
+    ;      ;
+    ;
+    ;      ; A quirk of ximovie is that it will crash if pos is set to the
+    ;      ; full size of the SJI images. I thus check the status of im_zoom:
+    ;      ; if no zoom (i.e., full image) then pos is not defined.
+    ;      ;
+    ;      im_zoom=state.wid_data.im_zoom
+    ;      IF im_zoom NE 0 THEN pos=[state.wid_data.sji_xrange,state.wid_data.sji_yrange]
+    ;
+    ;      widget_control,state.min_text_sji,get_value=sji_min
+    ;      widget_control,state.max_text_sji,get_value=sji_max
+    ;
+    ;      i=state.wid_data.sji_frame
+    ;      n=state.wid_data.sji_nframe
+    ;      d=state.wid_data.sji_mov_frames
+    ;
+    ;      IF d EQ n THEN BEGIN
+    ;        first_im=0
+    ;        last_im=n-1
+    ;      ENDIF ELSE BEGIN
+    ;        d2=fix((fix(d)-1)/2.)
+    ;        first_im=max([0,i-d2])
+    ;        last_im=min([i+d2,n-1])
+    ;      ENDELSE
+    ;
+    ;      state.sji_d->ximovie,pos=pos, log=state.wid_data.linlog, $
+    ;        first_im=first_im,last_im=last_im,start_im=i
+    ;    END
+    ;
+    ;    state.sji_frames_droplist: BEGIN
+    ;      widget_control,state.sji_frames_droplist,get_value=value
+    ;      result=value[event.index]
+    ;      IF trim(result) EQ 'all' THEN sji_mov_frames=state.wid_data.sji_nframe $
+    ;      ELSE sji_mov_frames=fix(result)
+    ;      state.wid_data.sji_mov_frames=sji_mov_frames
+    ;      ;
+    ;      ; Update the movie duration widget
+    ;      ;
+    ;      sji_mov_dur=(sji_mov_frames*state.wid_data.sji_cadence)/60.
+    ;      sji_mov_dur_txt=trim(string(sji_mov_dur,format='(f7.1)'))
+    ;      sji_dur_txt='Movie duration: '+sji_mov_dur_txt+' mins (approx)'
+    ;      widget_control,state.sji_dur_text,set_val=sji_dur_txt
+    ;      ;
+    ;      widget_control,state.spice_browser_base,set_uval=state
+    ;    END
 
     state.eis_butt: BEGIN
       t0=state.data->get_start_time()

--- a/quicklook/spice_raster_browser/spice_browser_get_metadata.pro
+++ b/quicklook/spice_raster_browser/spice_browser_get_metadata.pro
@@ -35,7 +35,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-08-29 14:18 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 FUNCTION spice_browser_get_metadata, data
@@ -104,8 +104,8 @@ FUNCTION spice_browser_get_metadata, data
   ;
   ; Get xcen and ycen
   ;
-  xcen = data->get_header_info('CRVAL1', 0)
-  ycen = data->get_header_info('CRVAL2', 0)
+  xcen = data->get_header_keyword('CRVAL1', 0)
+  ycen = data->get_header_keyword('CRVAL2', 0)
 
   ;
   ; Exposure times can vary between NUV and FUV, and also over time. The
@@ -123,8 +123,8 @@ FUNCTION spice_browser_get_metadata, data
     ypos: ypos, $
     tmid_min: tmid_min, $
     utc: utc, $
-    stud_acr: data->get_header_info('SPIOBSID', 0), $
-    date_obs: data->get_header_info('DATE-OBS', 0, ''), $
+    stud_acr: data->get_header_keyword('SPIOBSID', 0), $
+    date_obs: data->get_header_keyword('DATE-OBS', 0, ''), $
     l1p5_ver: 'NA', $
     obs_type: obs_type, $
     cadence: cadence, $

--- a/quicklook/spice_raster_browser/spice_browser_plot_image.pro
+++ b/quicklook/spice_raster_browser/spice_browser_plot_image.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 01.07.2020 10:55 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_plot_image, state, pwin, ps=ps
@@ -153,12 +153,12 @@ PRO spice_browser_plot_image, state, pwin, ps=ps
       axis,xaxis=1,xra=xra,xsty=1,charsiz=0.0001
     ENDIF ELSE BEGIN
       xra=[lam[i0],lam[i1]]
-      axis,xaxis=0,xra=xra,xsty=1,xtitle='Wavelength / '+state.data->get_header_info('CUNIT3', iwin, '')
+      axis,xaxis=0,xra=xra,xsty=1,xtitle='Wavelength / '+state.data->get_header_keyword('CUNIT3', iwin, '')
       axis,xaxis=1,xra=xra,xsty=1,charsiz=0.0001
     ENDELSE
     ;
     yra=ypos[[j0,j1]]
-    axis,yaxis=0,yra=yra,ytit='Y / '+state.data->get_header_info('CUNIT2', iwin, ''),ysty=1
+    axis,yaxis=0,yra=yra,ytit='Y / '+state.data->get_header_keyword('CUNIT2', iwin, ''),ysty=1
     axis,yaxis=1,yra=yra,charsiz=0.00001,ysty=1
     ;
     usersym,[0,-1,1,0,1,-1,0],[0,-1,1,0,-1,1,0],th=2

--- a/quicklook/spice_raster_browser/spice_browser_plot_sji.pro
+++ b/quicklook/spice_raster_browser/spice_browser_plot_sji.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-06-02 11:47 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_plot_sji, state
@@ -158,14 +158,14 @@ PRO spice_browser_plot_sji, state
     ;
     ; For roll=90, I need to reverse cdelt1.
     ;
-    xcen=state.data->get_header_info('CRVAL1', window_index)
-    ycen=state.data->get_header_info('CRVAL2', window_index)
+    xcen=state.data->get_header_keyword('CRVAL1', window_index)
+    ycen=state.data->get_header_keyword('CRVAL2', window_index)
     cdelt1=state.data->get_resolution(window_index, /x)
     cdelt2=state.data->get_resolution(window_index, /y)
-    crpix1=state.data->get_header_info('CRPIX1', window_index)
-    crpix2=state.data->get_header_info('CRPIX2', window_index)
-    fovx=cdelt1 * state.data->get_header_info('NAXIS1', window_index)
-    fovy=cdelt2 * state.data->get_header_info('NAXIS2', window_index)
+    crpix1=state.data->get_header_keyword('CRPIX1', window_index)
+    crpix2=state.data->get_header_keyword('CRPIX2', window_index)
+    fovx=cdelt1 * state.data->get_header_keyword('NAXIS1', window_index)
+    fovy=cdelt2 * state.data->get_header_keyword('NAXIS2', window_index)
     ;
     IF abs(state.wid_data.roll) GE 85 THEN BEGIN
       xc_temp=xcen

--- a/quicklook/spice_raster_browser/spice_browser_plot_sji.pro
+++ b/quicklook/spice_raster_browser/spice_browser_plot_sji.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-20 15:06 CEST $
 
 
 PRO spice_browser_plot_sji, state
@@ -147,7 +147,9 @@ PRO spice_browser_plot_sji, state
     ;data = state.data->get_window_data(window_index)
     ;help, data
     ;stop
-    image = state.data->get_one_image(window_index, 0)
+    widget_control, state.mask_butt, get_value=masking
+    no_masking=masking[0] eq 0
+    image = state.data->get_one_image(window_index, 0, no_masking=no_masking)
 
     ;
     ; Get SJI image coordinate information.

--- a/quicklook/spice_raster_browser/spice_browser_plot_spectrum.pro
+++ b/quicklook/spice_raster_browser/spice_browser_plot_spectrum.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 28.07.2020 21:20 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_plot_spectrum, state, pwin
@@ -45,7 +45,7 @@ PRO spice_browser_plot_spectrum, state, pwin
 
   spec=state.spectra[*,pwin]
 
-  nl=state.data->get_header_info('NAXIS3', iwin)
+  nl=state.data->get_header_keyword('NAXIS3', iwin)
   spec=spec[0:nl-1]
 
 
@@ -85,7 +85,7 @@ PRO spice_browser_plot_spectrum, state, pwin
     usersym,[-1,1,0,-1,1,0],[-1,1,0,1,-1,0],th=2
     plots,v[lpix],spec[lpix],psym=8,symsiz=2
   ENDIF ELSE BEGIN
-    xtitle='Wavelength / '+state.data->get_header_info('CUNIT3', iwin, '')
+    xtitle='Wavelength / '+state.data->get_header_keyword('CUNIT3', iwin, '')
     plot,wvl,spec,psym=10,/xsty,xrange=wrange, $
       tit=title,ysty=1,yrange=yrange, $
       xtitle=xtitle,ytitle=ytitle

--- a/quicklook/spice_raster_browser/spice_browser_update_image.pro
+++ b/quicklook/spice_raster_browser/spice_browser_update_image.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2021-10-26 14:18 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_update_image, state, pwin
@@ -52,8 +52,8 @@ PRO spice_browser_update_image, state, pwin
   iwin=state.wid_data.iwin[pwin]
   nx=state.wid_data.nx
   nxpos=state.wid_data.nxpos
-  ny=state.data->get_header_info('NAXIS2', iwin)
-  nl=state.data->get_header_info('NAXIS3', iwin)
+  ny=state.data->get_header_keyword('NAXIS2', iwin)
+  nl=state.data->get_header_keyword('NAXIS3', iwin)
 
   exptime=replicate(state.data->get_exposure_time(iwin), state.data->get_number_exposures(iwin))
 

--- a/quicklook/spice_raster_browser/spice_browser_update_image.pro
+++ b/quicklook/spice_raster_browser/spice_browser_update_image.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-20 15:06 CEST $
 
 
 PRO spice_browser_update_image, state, pwin
@@ -108,7 +108,9 @@ PRO spice_browser_update_image, state, pwin
   exptime=exptime[i0:i1]
   ;
   FOR i=i0,i1,dx DO BEGIN
-    expimg=state.data->get_one_image(iwin,i)
+    widget_control, state.mask_butt, get_value=masking
+    no_masking=masking[0] eq 0
+    expimg=state.data->get_one_image(iwin,i, no_masking=no_masking)
     expt=exptime[i-i0]
     IF expt NE 0. THEN wd[*,i-i0,*]=expimg[j0:j1,*]/expt ELSE wd[*,i-i0,*]=expimg[j0:j1,*]
   ENDFOR

--- a/quicklook/spice_raster_browser/spice_browser_update_info.pro
+++ b/quicklook/spice_raster_browser/spice_browser_update_info.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-08-29 14:18 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_update_info, state
@@ -53,7 +53,7 @@ PRO spice_browser_update_info, state
   IF xpix GE n THEN etstr='Earth Time: N/A' ELSE etstr='Earth Time: '+tmid_earth[xpix]
   widget_control,state.ettext,set_val=etstr
 
-  date_obs=state.data->get_header_info('DATE-BEG', 0)
+  date_obs=state.data->get_header_keyword('DATE-BEG', 0)
   if N_ELEMENTS(date_obs) eq 0 then begin
     val='TIME: N/A'
   endif else begin

--- a/quicklook/spice_raster_browser/spice_browser_update_spectrum.pro
+++ b/quicklook/spice_raster_browser/spice_browser_update_spectrum.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-20 15:06 CEST $
 
 
 PRO spice_browser_update_spectrum, state, pwin
@@ -85,7 +85,9 @@ PRO spice_browser_update_spectrum, state, pwin
   ; to be consistent with the raster image.
   ;
   IF xpix LT nx THEN BEGIN
-    expimg=state.data->get_one_image(iwin,xpix)
+    widget_control, state.mask_butt, get_value=masking
+    no_masking=masking[0] eq 0
+    expimg=state.data->get_one_image(iwin,xpix, no_masking=no_masking)
     IF exptime[xpix] NE 0. THEN expimg=expimg/exptime[xpix]
     state.expimages[0:nl-1,yoff:yoff+ny-1,pwin]=expimg
     state.spectra[0:nl-1,pwin]=expimg[*,ypix-yoff]

--- a/quicklook/spice_raster_browser/spice_browser_update_spectrum.pro
+++ b/quicklook/spice_raster_browser/spice_browser_update_spectrum.pro
@@ -34,7 +34,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2021-10-26 14:18 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_update_spectrum, state, pwin
@@ -48,7 +48,7 @@ PRO spice_browser_update_spectrum, state, pwin
   iwin=state.wid_data.iwin[pwin]
   xpix=state.wid_data.xpix
   ypix=state.wid_data.ypix
-  nl=state.data->get_header_info('NAXIS3', iwin)
+  nl=state.data->get_header_keyword('NAXIS3', iwin)
 
   exptime=replicate(state.data->get_exposure_time(iwin), state.data->get_number_exposures(iwin))
 
@@ -58,7 +58,7 @@ PRO spice_browser_update_spectrum, state, pwin
   xoff=state.wid_data.ichunk*state.wid_data.nxpos
 
   nx=state.wid_data.nx
-  ny=state.data->get_header_info('NAXIS2', iwin)
+  ny=state.data->get_header_keyword('NAXIS2', iwin)
   scale=state.wid_data.scale
 
   state.spectra[*,pwin]=0.

--- a/quicklook/spice_raster_browser/spice_browser_widget.pro
+++ b/quicklook/spice_raster_browser/spice_browser_widget.pro
@@ -49,7 +49,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-20 15:06 CEST $
 
 
 PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
@@ -532,6 +532,13 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
   endelse
 
   ;
+  ; MASKING option, mask regions outside of slit?
+  ; ---------------------------------
+  mask_base=widget_base(opt_base,/col,frame=1)
+  mask_butt=cw_bgroup(mask_base,['Mask regions outside slit'], $
+    set_value=[1],/nonexclusive,font=font,/row)
+
+  ;
   ; NEXP_PRP > 1 BUTTONS
   ; --------------------
   ;  IF nexp_prp GT 1 THEN BEGIN
@@ -902,6 +909,7 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
     exp_slider: exp_slider, $
     exp_butt1: exp_butt1, $
     exp_butt2: exp_butt2, $
+    mask_butt:mask_butt, $
     text3: text3, $
     min_text_sji: min_text_sji, $
     max_text_sji: max_text_sji, $

--- a/quicklook/spice_raster_browser/spice_browser_widget.pro
+++ b/quicklook/spice_raster_browser/spice_browser_widget.pro
@@ -49,7 +49,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2022-08-29 14:18 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
@@ -296,7 +296,7 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
     tmid: midtime, $
     tmid_min: tmid_min, $
     rast_direct: rast_direct, $
-    roll: data->get_header_info('CROTA', 0, 0), $
+    roll: data->get_header_keyword('CROTA', 0, 0), $
     l1p5_ver: meta.l1p5_ver, $
     sji: sji, $
     sji_file: sji_file, $     ; array of all SJI filenames
@@ -334,7 +334,7 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
   ; So we just use the sfirst 3 or 4 windows
   FOR i_plot_window=0,n_plot_window-1 DO BEGIN
     wid_data.iwin[i_plot_window] = i_plot_window
-    wid_data.lambda[i_plot_window] = data->get_header_info('CRVAL3', i_plot_window)
+    wid_data.lambda[i_plot_window] = data->get_header_keyword('CRVAL3', i_plot_window)
     lam = data->get_lambda_vector(i_plot_window)
     getmin = min(abs(lam), imin)
     wid_data.ilambda[i_plot_window] = imin
@@ -553,13 +553,13 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
   ;
   ; The following contains meta-data that goes on the Metadata tab.
   ;
-  stud_acr=data->get_header_info('OBS_ID', 0, '')
+  stud_acr=data->get_header_keyword('OBS_ID', 0, '')
   ;  IF n_tags(filestr) NE 0 THEN BEGIN
   ;    date_obs=filestr.t0
   ;    date_end=filestr.t1
   ;  ENDIF ELSE BEGIN
-  date_obs=data->get_header_info('DATE-BEG', 0, '')
-  date_end=data->get_header_info('DATE-END', 0, '')
+  date_obs=data->get_header_keyword('DATE-BEG', 0, '')
+  date_end=data->get_header_keyword('DATE-END', 0, '')
   ;  ENDELSE
   ;
   text1=widget_label(meta_base,val='OBSID: '+stud_acr,font=font, $
@@ -592,9 +592,9 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
   text4=widget_label(meta_base,val='CADENCE: '+cadstr,font=font, $
     /align_left)
   ;  ENDIF
-  nuvbin=data->get_header_info('NBIN3', 0)
-  fuvbin=data->get_header_info('NBIN3', 0)
-  spatbin=data->get_header_info('NBIN2', 0)
+  nuvbin=data->get_header_keyword('NBIN3', 0)
+  fuvbin=data->get_header_keyword('NBIN3', 0)
+  spatbin=data->get_header_keyword('NBIN2', 0)
   text5a=widget_label(meta_base,val='FUV SPEC BIN: '+trim(fuvbin),font=font, $
     /align_left)
   text5b=widget_label(meta_base,val='NUV SPEC BIN: '+trim(nuvbin),font=font, $
@@ -822,7 +822,7 @@ PRO spice_browser_widget, data, yoffsets=yoffsets, quiet=quiet, $
   ;
   nl = intarr(data->get_number_windows())
   FOR i=0,data->get_number_windows()-1 DO BEGIN
-    nl[i] = data->get_header_info('NAXIS3', i)
+    nl[i] = data->get_header_keyword('NAXIS3', i)
   END
   spectra=fltarr(max(nl),n_plot_window)
 

--- a/quicklook/spice_raster_browser/spice_raster_browser.pro
+++ b/quicklook/spice_raster_browser/spice_raster_browser.pro
@@ -103,7 +103,7 @@
 ;     Ver. 1, 22-Nov-2019, Martin Wiesmann
 ;       modified from iris_raster_browser.
 ;-
-; $Id: 2021-04-22 10:01 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 ;---------------------
@@ -146,16 +146,16 @@ PRO spice_raster_browser, input_data, quiet=quiet, yoffsets=yoffsets, $
   ;  ENDIF
 
   IF NOT keyword_set(quiet) THEN BEGIN
-    box_message, ['FILENAME = ' + data->get_header_info('FILENAME', 0), $
-      'EXTNAME  = ' + data->get_header_info('EXTNAME', 0), $
-      'STUDYTYP = ' + data->get_header_info('STUDYTYP', 0), $
-      'STUDYDES = ' + data->get_header_info('STUDYDES', 0, ''), $
-      'STUDY    = ' + data->get_header_info('STUDY', 0, ''), $
-      'OBS_TYPE = ' + data->get_header_info('OBS_TYPE', 0, ''), $
-      'OBS_ID   = ' + data->get_header_info('OBS_ID', 0, ''), $
-      'SPIOBSID = ' + strtrim(string(data->get_header_info('SPIOBSID', 0)), 2), $
-      'PURPOSE  = ' + data->get_header_info('PURPOSE', 0, ''), $
-      'SOOPNAME = ' + data->get_header_info('SOOPNAME', 0, '')]
+    box_message, ['FILENAME = ' + data->get_header_keyword('FILENAME', 0), $
+      'EXTNAME  = ' + data->get_header_keyword('EXTNAME', 0), $
+      'STUDYTYP = ' + data->get_header_keyword('STUDYTYP', 0), $
+      'STUDYDES = ' + data->get_header_keyword('STUDYDES', 0, ''), $
+      'STUDY    = ' + data->get_header_keyword('STUDY', 0, ''), $
+      'OBS_TYPE = ' + data->get_header_keyword('OBS_TYPE', 0, ''), $
+      'OBS_ID   = ' + data->get_header_keyword('OBS_ID', 0, ''), $
+      'SPIOBSID = ' + strtrim(string(data->get_header_keyword('SPIOBSID', 0)), 2), $
+      'PURPOSE  = ' + data->get_header_keyword('PURPOSE', 0, ''), $
+      'SOOPNAME = ' + data->get_header_keyword('SOOPNAME', 0, '')]
   ENDIF
 
   spice_browser_widget, data, yoffsets=yoffsets, chunk_size=chunk_size, $

--- a/quicklook/spice_xdetector.pro
+++ b/quicklook/spice_xdetector.pro
@@ -47,7 +47,7 @@
 ;       10-Feb-2020: Martin Wiesmann: Rewritten for SPICE data
 ;
 ;-
-; $Id: 2022-06-03 14:50 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 ; save as postscript file
@@ -879,7 +879,7 @@ pro spice_xdetector, input_data, lindx, group_leader = group_leader, $
   ; win_positions due to transformations
   if data->get_level() eq 2 then begin
     for i=0,nwin-1 do begin
-      sizey = data->get_header_info('NAXIS2', lindx[i])* data->get_spatial_binning(lindx[i])
+      sizey = data->get_header_keyword('NAXIS2', lindx[i])* data->get_spatial_binning(lindx[i])
       dy = sizey - (win_positions[i,3]-win_positions[i,2]+1)
       if dy ne 0 then begin
         dy1 = fix(dy/2.0)
@@ -895,7 +895,7 @@ pro spice_xdetector, input_data, lindx, group_leader = group_leader, $
           win_positions[i,3] = ccd_size[1]-1
         endif
       endif
-      sizel = data->get_header_info('NAXIS3', lindx[i])* data->get_spectral_binning(lindx[i])
+      sizel = data->get_header_keyword('NAXIS3', lindx[i])* data->get_spectral_binning(lindx[i])
       dl = sizel - (win_positions[i,1]-win_positions[i,0]+1)
       if dl ne 0 then begin
         dl1 = fix(dl/2.0)

--- a/quicklook/spice_xmap.pro
+++ b/quicklook/spice_xmap.pro
@@ -16,7 +16,7 @@
 ;       spice_xmap, data [, linelist = linelist, group_leader = groupleader, ncolors=ncolors]
 ;
 ; INPUTS:
-;       data: Can be either the name and path of a SPICE data file, 
+;       data: Can be either the name and path of a SPICE data file,
 ;             or a SPICE data object.
 ;
 ; KEYWORD PARAMETERS:
@@ -69,7 +69,7 @@
 ;       22-Jan-2013: V. Hansteen - First IRIS modified version.
 ;       28-May-2020: M. Wiesmann - First SPICE modified version.
 ;
-; $Id: 2022-06-02 11:47 CEST $
+; $Id: 2022-09-21 11:47 CEST $
 ;-
 ;
 ; save as postscript file
@@ -711,6 +711,18 @@ pro spice_xmap_pixplot, event
   endcase
 end
 
+; Toggle masking on/off
+pro spice_xmap_mask, event
+  widget_control, event.top, get_uvalue = info
+  widget_control, (*info).maskbutton, get_value=masking
+  wd = *(*info).data->get_window_data((*info).line, no_masking=masking eq 0)
+  *(*info).wd = wd
+  ; draw image
+  pseudoevent={widget_base,id:0l, $
+    top:(*info).tlb, handler:0l, x:(*info).tlb_xsz, y:(*info).tlb_ysz}
+  spice_xmap_resize, pseudoevent
+end
+
 ; save data
 pro spice_xmap_save_moments, event
   widget_control, event.top, get_uvalue = info
@@ -768,7 +780,7 @@ pro spice_xmap, input_data, linelist = linelist, group_leader = group_leader, $
   data = spice_get_object(input_data, is_spice=is_spice, object_created=object_created)
   if ~is_spice then return
 
-; drawing window size in relation to screen
+  ; drawing window size in relation to screen
   if n_elements(scfac) eq 0 then scfac=0.8
   if n_elements(standard_size) eq 0 then standard_size=700
   if n_elements(ncolors) eq 0 then ncolors = (!d.n_colors < 256)
@@ -972,6 +984,12 @@ pro spice_xmap, input_data, linelist = linelist, group_leader = group_leader, $
   pixelplot = widget_droplist(pixplotfield, value = pixnames, $
     title = 'Plot pixel values', $
     event_pro = 'spice_xmap_pixplot')
+
+  maskfield = widget_base(lcol, /column, /frame, event_pro = 'spice_xmap_mask')
+  maskbutton = cw_bgroup(maskfield, ['Mask regions outside slit'], $
+    set_value=[1],/nonexclusive)
+
+
   ; menu for preset widget sizes
   drawsizeoption = widget_base(lcol, /column, /frame)
   drawsizeoption_title = widget_label(drawsizeoption, value = 'Resize widget')
@@ -1147,6 +1165,7 @@ pro spice_xmap, input_data, linelist = linelist, group_leader = group_leader, $
     line:line, $
     linelist:linelist, $
     dpnr:0, $
+    maskbutton:maskbutton, $
     ;comment:comment, $
     screensize:screensize, $
     keep_aspect:0, $

--- a/quicklook/spice_xraster.pro
+++ b/quicklook/spice_xraster.pro
@@ -62,7 +62,7 @@
 ;       17-Jan-2013: V. Hansteen    - rewritten as iris_xraster
 ;       19-May-2020: M. Wiesmann    - rewritten as spice_xraster
 ;
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-21 10:42 CEST $
 ;-
 ;
 ; save as postscript file
@@ -145,7 +145,7 @@ pro spice_xraster_draw, event
   for i = 0, (*info).nwin-1 do begin
     j = (*info).windows[i]
     for it=0,min([5,nr-1]) do begin
-      var=*(*info).data->get_one_image(j,it)
+      var=*(*info).data->get_one_image(j,it,no_masking=(*info).no_masking)
       wdmin[i]=min([min(iris_histo_opt(var,0.01,/bot_only,missing=missing),/nan),wdmin[i]],/nan)
       wdmax[i]=max([max(iris_histo_opt(var,0.001,/top_only,missing=missing),/nan),wdmax[i]],/nan)
     endfor
@@ -178,7 +178,7 @@ pro spice_xraster_draw, event
 
     ; draw images
     for it = 0, nr-1 do begin
-      drawimage = congrid(*(*info).data->get_one_image(j,it),xpix,ypix)
+      drawimage = congrid(*(*info).data->get_one_image(j,it,no_masking=(*info).no_masking),xpix,ypix)
       sz=size(drawimage)
       scale=[(max(xscale)-min(xscale))/sz[1],(max(yscale)-min(yscale))/sz[2]]
       ymin = wdmin[i]
@@ -359,6 +359,26 @@ pro spice_xraster_wangstr, event
   ; set titles for image plots
   (*info).xtitle = *(*info).data->get_axis_title((*info).xdim)
   (*info).xdim_unit = 1
+  pseudoevent={widget_button,id:0L, $
+    top:event.top, handler:0l, select:1}
+  spice_xraster_draw, pseudoevent
+end
+
+; Toggle masking of pixels outside slit ON
+pro spice_xraster_mask_on, event
+  widget_control, event.top, get_uvalue = info
+  ; set titles for image plots
+  (*info).no_masking = 0
+  pseudoevent={widget_button,id:0L, $
+    top:event.top, handler:0l, select:1}
+  spice_xraster_draw, pseudoevent
+end
+
+; Toggle masking of pixels outside slit OFF
+pro spice_xraster_mask_off, event
+  widget_control, event.top, get_uvalue = info
+  ; set titles for image plots
+  (*info).no_masking = 1
   pseudoevent={widget_button,id:0L, $
     top:event.top, handler:0l, select:1}
   spice_xraster_draw, pseudoevent
@@ -574,6 +594,9 @@ pro spice_xraster, input_data, windows, ncolors=ncolors, group_leader = group_le
   sscalemenu=widget_button(optmenu, value='Change spatial scale',/menu)
   pixmenu=widget_button(sscalemenu, value='Pixels',event_pro='spice_xraster_spix')
   angstrmenu=widget_button(sscalemenu, value='arcsec',event_pro='spice_xraster_sarcsec')
+  maskmenu=widget_button(optmenu, value='Toggle masking', /menu)
+  maskonmenu=widget_button(maskmenu, value='On',event_pro='spice_xraster_mask_on')
+  maskoffmenu=widget_button(maskmenu, value='Off',event_pro='spice_xraster_mask_off')
 
   ; display window:
   displaybase = widget_base(rcol, /row)
@@ -633,6 +656,7 @@ pro spice_xraster, input_data, windows, ncolors=ncolors, group_leader = group_le
     xs:0, $
     ys:0, $
     redraw:0, $
+    no_masking:0, $
     timer:'off', $
     x_scroll_size:d_xsz, $
     y_scroll_size:d_ysz, $

--- a/quicklook/spice_xraster.pro
+++ b/quicklook/spice_xraster.pro
@@ -62,7 +62,7 @@
 ;       17-Jan-2013: V. Hansteen    - rewritten as iris_xraster
 ;       19-May-2020: M. Wiesmann    - rewritten as spice_xraster
 ;
-; $Id: 2021-10-26 14:49 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 ;-
 ;
 ; save as postscript file
@@ -120,8 +120,8 @@ pro spice_xraster_draw, event
     j=(*info).windows[i]
     ;pos=*(*info).data->getpos(j)
     ;sz = size(wd)
-    xsz = xsz > *(*info).data->get_header_info('naxis3', j)
-    ysz = ysz > *(*info).data->get_header_info('naxis2', j)
+    xsz = xsz > *(*info).data->get_header_keyword('naxis3', j)
+    ysz = ysz > *(*info).data->get_header_keyword('naxis2', j)
   endfor
   ; determine size of each window. The scale factors
   ; (xpixels*2)x(ypixels/2), with a minimum of

--- a/quicklook/spice_xwhisker.pro
+++ b/quicklook/spice_xwhisker.pro
@@ -52,7 +52,7 @@
 ;       28-Jan-2020: M. Wiesmann    - Rewritten for SPICE as spice_xwhisker
 ;
 ;-
-; $Id: 2022-06-02 11:47 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 
 ; save as postscript file
@@ -612,7 +612,7 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
   d_ysz = sz[0]/1.4
   ;
   sit_and_stare = data->get_sit_and_stare()
-  nslit=data->get_header_info('NAXIS2', line)
+  nslit=data->get_header_keyword('NAXIS2', line)
   nraster = data->get_number_exposures(line)
   nexpprp = 1 ;data->getnexp_prp(line)  ; number of exp pr. raster pos.
   slitpos = nslit/2
@@ -726,8 +726,8 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
 
   xycenbase = widget_base(exposurebase,/col)
   xycentext = widget_label(xycenbase, $
-    value = 'Xcen: '+ string((data->get_header_info('crval1', line)),format='(f8.3)')+ $
-    ' Ycen: '+ string((data->get_header_info('crval2', line)),format='(f8.3)'), $
+    value = 'Xcen: '+ string((data->get_header_keyword('crval1', line)),format='(f8.3)')+ $
+    ' Ycen: '+ string((data->get_header_keyword('crval2', line)),format='(f8.3)'), $
     /align_left)
 
   rot=data->get_satellite_rotation()

--- a/quicklook/spice_xwhisker.pro
+++ b/quicklook/spice_xwhisker.pro
@@ -16,7 +16,7 @@
 ;       spice_xwhisker, data, line [, group_leader = group_leader, ncolors = ncolors]
 ;
 ; INPUTS:
-;       data: Can be either the name and path of a SPICE data file, 
+;       data: Can be either the name and path of a SPICE data file,
 ;             or a SPICE data object.
 ;       line: The index of the line window to be displayed
 ;
@@ -52,7 +52,7 @@
 ;       28-Jan-2020: M. Wiesmann    - Rewritten for SPICE as spice_xwhisker
 ;
 ;-
-; $Id: 2022-09-20 14:35 CEST $
+; $Id: 2022-09-22 13:47 CEST $
 
 
 ; save as postscript file
@@ -216,11 +216,7 @@ pro spice_xwhisker_expprp_slider, event
   (*info).exprp=event.value
   (*info).expindx = indgen((*info).nraster)*(*info).nexpprp + (*info).exprp - 1
   nr=(*info).exprp-1
-  ;  message = ['Loading data into memory...','...this may take some time']
-  ;  xmessage,message,wbase=wbase,font='helvetica'
-  ;  wd=(*(*info).data)->getvar((*info).line,/load)
   wd=*(*info).wd
-  ;  xkill,wbase
   (*info).image = reform(wd[*,(*info).slitpos,(*info).expindx])
   good=finite((*info).image)
   if (where(good))[0] eq -1 then begin
@@ -239,7 +235,7 @@ pro spice_xwhisker_expprp_slider, event
     pzty=(*(*info).data->getypos((*info).line))[(*info).slitpos]
   endelse
   widget_control,(*info).fmirrytext, $
-    set_value = 'Y: '+ string(pzty,format='(f8.3)')+' arcsec'
+    set_value = 'Y: '+ string(pzty,format='(f10.3)')+' arcsec'
   ; display new exposure nr
   pseudoevent={widget_button,id:0L, $
     top:event.top, handler:0l, select:1}
@@ -251,11 +247,7 @@ end
 pro spice_xwhisker_slitslider, event
   widget_control, event.top,get_uvalue=info
   (*info).slitpos=event.value
-  message = ['Loading data into memory...','...this may take some time']
-  ;  xmessage,message,wbase=wbase,font='helvetica'
-  ;  wd=(*(*info).data)->getvar((*info).line,/load)
   wd=*(*info).wd
-  ;  xkill,wbase
   if (*info).nexpprp le 1 then begin
     (*info).image = reform(wd[*,(*info).slitpos,*])
   endif else begin
@@ -277,7 +269,7 @@ pro spice_xwhisker_slitslider, event
     slittxt='Y: '
   endelse
   widget_control,(*info).fmirrytext, $
-    set_value = slittxt + string(pzty[0],format='(f8.3)')+' arcsec'
+    set_value = slittxt + string(pzty[(*info).slitpos],format='(f10.3)')+' arcsec'
   ; display new raster position
   pseudoevent={widget_button,id:0L, $
     top:event.top, handler:0l, select:1}
@@ -570,6 +562,26 @@ pro spice_xwhisker_lineplot, event
 end
 
 
+pro spice_xwhisker_mask, event
+  widget_control, event.top, get_uvalue = info
+  widget_control, (*info).maskbutton, get_value=masking
+  print,masking
+  wd = *(*info).data->get_window_data((*info).line, no_masking=masking eq 0)
+  image = reform(wd[*,(*info).slitpos,*,*])
+  if *(*info).data->get_missing_value() ne *(*info).data->get_missing_value() then missing=-99999L $
+  else missing=*(*info).data->get_missing_value()
+  wd=iris_histo_opt(wd,missing=missing)
+  imin=min(wd)
+  imax=max(wd)
+  image=iris_histo_opt(image)
+  *(*info).wd = wd
+  (*info).image = image
+  pseudoevent={widget_button,id:0L, $
+    top:event.top,handler:0l,select:1}
+  spice_xwhisker_draw, pseudoevent
+end
+
+
 ; close spice_xwhisker
 pro spice_xwhisker_destroy, event
   widget_control, event.top,/destroy
@@ -648,7 +660,7 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
   ysz = sz[3]
   ;
   xdim = 2
-  if sit_and_stare then ydim = 3 else ydim = 1
+  if sit_and_stare then ydim = 3 else ydim = 0
   xtitle = data->get_axis_title(xdim)
   ytitle = data->get_axis_title(ydim)
   window, /pixmap, /free, xsize = xsz, ysize = ysz
@@ -726,8 +738,8 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
 
   xycenbase = widget_base(exposurebase,/col)
   xycentext = widget_label(xycenbase, $
-    value = 'Xcen: '+ string((data->get_header_keyword('crval1', line)),format='(f8.3)')+ $
-    ' Ycen: '+ string((data->get_header_keyword('crval2', line)),format='(f8.3)'), $
+    value = 'Xcen: '+ string((data->get_header_keyword('crval1', line)),format='(f10.3)')+ $
+    ' Ycen: '+ string((data->get_header_keyword('crval2', line)),format='(f10.3)'), $
     /align_left)
 
   rot=data->get_satellite_rotation()
@@ -742,13 +754,19 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
     slittxt='Y: '
   endelse
   fmirrytext = widget_label(exposurebase, $
-    value = strtrim(slittxt+ string(pzty[0],format='(f8.3)'),2)+' arcsec', $
+    value = strtrim(slittxt+ string(pzty[slitpos],format='(f10.3)'),2)+' arcsec', $
     /align_left)
 
   title = 'Slit Position'
   slitslider = widget_slider(sliderbase, xsize=90, $
     minimum=0, maximum=nslit-1, title=title, $
     value=slitpos, event_pro='spice_xwhisker_slitslider',/drag)
+
+  maskfield = widget_base(lcol, /column, /frame, event_pro = 'spice_xwhisker_mask')
+  maskbutton = cw_bgroup(maskfield, ['Mask regions outside slit'], $
+    set_value=[1],/nonexclusive)
+
+
   ; control of gamma and histo_
   gammacol = widget_base(lcol, /row)
   gamma=1.0
@@ -820,6 +838,7 @@ pro spice_xwhisker , input_data, line, group_leader = group_leader, $
     exprp:1, $
     ndim:ndim, $
     line:line, $
+    maskbutton:maskbutton, $
     screensize:screensize, $
     lcol_xsz:lcol_xsz, $
     d_xsz:d_xsz, $

--- a/test_data/spice_test.pro
+++ b/test_data/spice_test.pro
@@ -26,17 +26,17 @@ PRO spice_test, file_number
   ;d = spice_getwindata(obj, window_index)
   ;help,d
 
-  ;print, 'NAXIS1 : ' + strtrim(string(obj->get_header_info('NAXIS1', window_index)),2)
-  ;print, 'NAXIS2 : ' + strtrim(string(obj->get_header_info('NAXIS2', window_index)),2)
-  ;print, 'NAXIS3 : ' + strtrim(string(obj->get_header_info('NAXIS3', window_index)),2)
-  ;print, 'NAXIS4 : ' + strtrim(string(obj->get_header_info('NAXIS4', window_index)),2)
+  ;print, 'NAXIS1 : ' + strtrim(string(obj->get_header_keyword('NAXIS1', window_index)),2)
+  ;print, 'NAXIS2 : ' + strtrim(string(obj->get_header_keyword('NAXIS2', window_index)),2)
+  ;print, 'NAXIS3 : ' + strtrim(string(obj->get_header_keyword('NAXIS3', window_index)),2)
+  ;print, 'NAXIS4 : ' + strtrim(string(obj->get_header_keyword('NAXIS4', window_index)),2)
 
   for i=0,obj->get_number_windows()-1 do begin
     ;print,obj->get_window_position(i)
-    ;print, strcompress(string(i)) + '  : ' + strtrim(string(obj->get_header_info('NAXIS1', window_index)),2) + $
-    ;  '  : ' + strtrim(string(obj->get_header_info('NAXIS2', window_index)),2) + $
-    ;  '  : ' + strtrim(string(obj->get_header_info('NAXIS3', window_index)),2) + $
-    ;  '  : ' + strtrim(string(obj->get_header_info('NAXIS4', window_index)),2)
+    ;print, strcompress(string(i)) + '  : ' + strtrim(string(obj->get_header_keyword('NAXIS1', window_index)),2) + $
+    ;  '  : ' + strtrim(string(obj->get_header_keyword('NAXIS2', window_index)),2) + $
+    ;  '  : ' + strtrim(string(obj->get_header_keyword('NAXIS3', window_index)),2) + $
+    ;  '  : ' + strtrim(string(obj->get_header_keyword('NAXIS4', window_index)),2)
   endfor
 
   ;spice_xdetector, obj, indgen(obj->get_number_windows())

--- a/test_data/spice_test_privat.pro
+++ b/test_data/spice_test_privat.pro
@@ -228,17 +228,17 @@ PRO spice_test_privat, file_number
   ;help, obj->get_missing_value()
   ;stop
 
-  ;print, 'NAXIS1 : ' + strtrim(string(obj->get_header_info('NAXIS1', window_index)),2)
-  ;print, 'NAXIS2 : ' + strtrim(string(obj->get_header_info('NAXIS2', window_index)),2)
-  ;print, 'NAXIS3 : ' + strtrim(string(obj->get_header_info('NAXIS3', window_index)),2)
-  ;print, 'NAXIS4 : ' + strtrim(string(obj->get_header_info('NAXIS4', window_index)),2)
+  ;print, 'NAXIS1 : ' + strtrim(string(obj->get_header_keyword('NAXIS1', window_index)),2)
+  ;print, 'NAXIS2 : ' + strtrim(string(obj->get_header_keyword('NAXIS2', window_index)),2)
+  ;print, 'NAXIS3 : ' + strtrim(string(obj->get_header_keyword('NAXIS3', window_index)),2)
+  ;print, 'NAXIS4 : ' + strtrim(string(obj->get_header_keyword('NAXIS4', window_index)),2)
 
   for i=0,obj->get_number_windows()-1 do begin
     ;print,obj->get_window_position(i)
-    print, strcompress(string(i)) + '  : ' + strtrim(string(obj->get_header_info('NAXIS1', window_index)),2) + $
-      '  : ' + strtrim(string(obj->get_header_info('NAXIS2', window_index)),2) + $
-      '  : ' + strtrim(string(obj->get_header_info('NAXIS3', window_index)),2) + $
-      '  : ' + strtrim(string(obj->get_header_info('NAXIS4', window_index)),2)
+    print, strcompress(string(i)) + '  : ' + strtrim(string(obj->get_header_keyword('NAXIS1', window_index)),2) + $
+      '  : ' + strtrim(string(obj->get_header_keyword('NAXIS2', window_index)),2) + $
+      '  : ' + strtrim(string(obj->get_header_keyword('NAXIS3', window_index)),2) + $
+      '  : ' + strtrim(string(obj->get_header_keyword('NAXIS4', window_index)),2)
   endfor
   ;print,obj->get_spatial_binning()
   ;print,obj->get_spectral_binning()

--- a/utils/spice_getwindata.pro
+++ b/utils/spice_getwindata.pro
@@ -152,7 +152,7 @@
 ;       approximated_slit, if set (when slit_only is set) use a quicker way 
 ;       of estimating the pixels to be masked
 ;-
-; $Id: 2022-08-10 11:17 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 
 FUNCTION spice_getwindata, input_file, input_iwin, keep_sat=keep_sat, $
   clean=clean, wrange=wrange, verbose=verbose, $
@@ -498,8 +498,8 @@ dark_unc=0
     scale=[xscale,yscale]
     xpos=xpos[ix0:ix1]
   ENDIF ELSE BEGIN
-    dx=d->get_header_info('CDELT1',iwin)   ; perpendicular to slit
-    dy=d->get_header_info('CDELT2',iwin)   ; along slit
+    dx=d->get_header_keyword('CDELT1',iwin)   ; perpendicular to slit
+    dy=d->get_header_keyword('CDELT2',iwin)   ; along slit
     IF d->get_sit_AND_stare() EQ 1 THEN xpos=fltarr(nx)+0 ELSE xpos=findgen(nx)*dx
     ypos=findgen(ny)*dy
     scale=[dx,dy]
@@ -547,8 +547,8 @@ dark_unc=0
     scale: scale, $
     solar_x: xpos, $
     solar_y: ypos, $
-    xcen: d->get_header_info('CRVAL1',0), $
-    ycen: d->get_header_info('CRVAL2',0), $
+    xcen: d->get_header_keyword('CRVAL1',0), $
+    ycen: d->get_header_keyword('CRVAL2',0), $
     units: units, $
     missing: missing_val, $
     iwin: iwin, $

--- a/utils/spice_xcontrol.pro
+++ b/utils/spice_xcontrol.pro
@@ -34,7 +34,7 @@
 ;      1-Jan-2013: First version started by Viggo Hansteen
 ;     16-Sep-2020: First version for SPICE started by Martin Wiesmann
 ;
-; $Id: 2022-09-12 13:38 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 ;-
 ;
 ;
@@ -64,12 +64,12 @@ pro spice_xcontrol_get_data_info, info
   ;nraster=*(*info).d->getnraster()
   line=strarr(99)
   line[0] = 'SPIOBSID: '+*(*info).d->get_obs_id()
-  line[1] = 'SEQ_BEG : '+*(*info).d->get_header_info('SEQ_BEG', 0, '')
+  line[1] = 'SEQ_BEG : '+*(*info).d->get_header_keyword('SEQ_BEG', 0, '')
   line[2] = 'DATE-BEG: '+*(*info).d->get_start_time()
-  line[3] = 'STUDYTYP: '+*(*info).d->get_header_info('STUDYTYP', 0, '')
-  line[4] = 'STUDYDES: '+*(*info).d->get_header_info('STUDYDES', 0, '')
-  line[5] = 'AUTHOR  : '+*(*info).d->get_header_info('AUTHOR', 0, '')
-  line[6] = 'PURPOSE : '+*(*info).d->get_header_info('PURPOSE', 0, '')
+  line[3] = 'STUDYTYP: '+*(*info).d->get_header_keyword('STUDYTYP', 0, '')
+  line[4] = 'STUDYDES: '+*(*info).d->get_header_keyword('STUDYDES', 0, '')
+  line[5] = 'AUTHOR  : '+*(*info).d->get_header_keyword('AUTHOR', 0, '')
+  line[6] = 'PURPOSE : '+*(*info).d->get_header_keyword('PURPOSE', 0, '')
   line[7] = '========================================================'
   line[8] = 'CROTA   : '+string(*(*info).d->get_satellite_rotation(), format='(F9.2)')
   line[9] = 'XCEN    : '+string(*(*info).d->get_xcen(0), format='(F8.1)') + '   ' + $

--- a/utils/spice_xcontrol_detector.pro
+++ b/utils/spice_xcontrol_detector.pro
@@ -45,7 +45,7 @@
 ; MODIFICATION HISTORY:
 ;     17-Nov-2020: Martin Wiesmann, First version
 ;
-; $Id: 2022-06-03 14:50 CEST $
+; $Id: 2022-09-20 14:35 CEST $
 ;-
 ;
 
@@ -69,7 +69,7 @@ FUNCTION spice_xcontrol_detector, data, detector2=detector2, xsize=xsize, ysize=
   ; win_positions due to transformations
   if data->get_level() eq 2 then begin
     for i=0,nwin-1 do begin
-      sizey = data->get_header_info('NAXIS2', i) * data->get_spatial_binning(i)
+      sizey = data->get_header_keyword('NAXIS2', i) * data->get_spatial_binning(i)
       dy = sizey - (win_positions[i,3]-win_positions[i,2]+1)
       if dy ne 0 then begin
         dy1 = fix(dy/2.0)
@@ -85,7 +85,7 @@ FUNCTION spice_xcontrol_detector, data, detector2=detector2, xsize=xsize, ysize=
           win_positions[i,3] = ccd_size[1]-1
         endif
       endif
-      sizel = data->get_header_info('NAXIS3', i) * data->get_spectral_binning(i)
+      sizel = data->get_header_keyword('NAXIS3', i) * data->get_spectral_binning(i)
       dl = sizel - (win_positions[i,1]-win_positions[i,0]+1)
       if dl ne 0 then begin
         dl1 = fix(dl/2.0)

--- a/utils/spice_xfiles.pro
+++ b/utils/spice_xfiles.pro
@@ -63,7 +63,7 @@
 ;       Aug/Sep 2020:Martin Wiesmann, adapted it to SPICE and renamed it to
 ;                    spice_xfiles
 ;
-; $Id: 2022-09-12 13:45 CEST $
+; $Id: 2022-09-20 15:05 CEST $
 ;-
 
 
@@ -204,7 +204,7 @@ pro spice_xfiles_display_results, info, newfiles=newfiles
       spiobsids = file_info.spiobsid
       ptr_free, (*info).file_spiobsids
       (*info).file_spiobsids = ptr_new(spiobsids)
-  
+
       ; set all possible filter values (only used when this method is called from spice_xfiles_searchdir
       purpose = [purpose, hdr[uniq(hdr.purpose, sort(hdr.purpose))].purpose]
       studytyp = [studytyp, hdr[uniq(hdr.studytyp, sort(hdr.studytyp))].studytyp]
@@ -249,7 +249,7 @@ pro spice_xfiles_display_results, info, newfiles=newfiles
             ind = where(spiobsids eq hdr[ihdr].spiobsid, countobs)
             if countobs gt 0 then file2obsmap[ind]=ihdr+1
           endfor ; ihdr=0,countsw-1
-    
+
           OBSdesc = get_infox(hdr, 'SEQ_BEG, SPIOBSID, PURPOSE, STUDYTYP, DSUN_AU, SLIT_WID, CROTA, CRVAL1, CRVAL2, STUDYDES', header=header, $
             format='a,(I12),a,a,(f7.3),(I8),(f7.1),(f7.1),(f7.1),a')
           OBSdesc = [header, OBSdesc]
@@ -511,7 +511,8 @@ end
 ; call spice_xcontrol with the selected file
 pro spice_xfiles_read, event
   widget_control, event.top, get_uvalue = info
-  widget_control, event.id, get_uvalue = xcontrol_l23
+  IF event.id NE 0 THEN widget_control, event.id, get_uvalue = xcontrol_l23 $
+  ELSE xcontrol_l23 = 0
   file = ((*info).fileselect)
   if file eq '' then begin
     box_message,'You need to select a file first'
@@ -625,11 +626,11 @@ pro spice_xfiles
   label = widget_label(search_path_base, value='     ')
   ;searchstopbutton = widget_button(search_path_base, value='Stop Search', event_func='spice_xfiles_stopsearch')
   use_catalog_button = widget_button(search_path_base, value='Use catalog', event_pro='spice_xfiles_use_catalog')
-  
+
   ; display filter
   display_filter_base = widget_base(row4, /row, event_pro='spice_xfiles_change_display_filter')
   display_filter_label = widget_label(display_filter_base, value='Filter displayed OBS: ')
-  display_filter_purpose = widget_droplist(display_filter_base, value=['All'], title='Purpose', xsize=230)  
+  display_filter_purpose = widget_droplist(display_filter_base, value=['All'], title='Purpose', xsize=230)
   display_filter_studytyp = widget_droplist(display_filter_base, value=['All'], title='Study Type', xsize=200)
   display_filter_slitwid_label = widget_label(display_filter_base, value='Slit width:')
   display_filter_slitwid_min = cw_field(display_filter_base, title='min', value = 0, /integer, /return_events, xsize = 6)


### PR DESCRIPTION
- XDetector, Raster_browser, XMap and XWhisker have now an additional button, which allows the user to switch between showing the data with or without masking the pixels outside of the slit
- In XRaster this done via the Pull-down menu
- Inernally, all calls to get_header_info have been changed to get_header_keyword, since the first one is deprecated
- Fixes a couple of bugs