### PR TITLE
Improves prits_tools__parcheck

### DIFF
--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -1,11 +1,11 @@
 ;+
-; Name        :	
+; Name        :
 ;	PARCHECK
-; Purpose     :	
+; Purpose     :
 ;	Routine to check user parameters to a procedure
-; Explanation :	
+; Explanation :
 ;	Routine to check user parameters to a procedure
-; Use         :	
+; Use         :
 ;       pt.parcheck, parameter, parnum, name,  types, valid_ndims, default=default, $
 ;                             maxval=maxval,minval=minval, $
 ;                             result=result
@@ -15,13 +15,13 @@
 ;	IDL> parcheck, hdr, 2, 7, 1, 'FITS Image Header'
 ;
 ;	This example checks whether the parameter 'hdr' is of type string (=7)
-;	and is a vector (1 dimension).   If either of these tests fail, a 
+;	and is a vector (1 dimension).   If either of these tests fail, a
 ;	message will be printed
 ;		"Parameter 2 (FITS Image Header) is undefined"
 ;		"Valid dimensions are 1"
-;		"Valid types are string"	
+;		"Valid types are string"
 ;
-; Inputs      :	
+; Inputs      :
 ;	parameter - parameter passed to the routine
 ;	parnum    - integer parameter number
 ;	types     - integer or string, scalar or vector of valid types
@@ -44,7 +44,7 @@
 ;	dimens   - integer scalar or vector giving number of allowed dimensions.
 ;	           for scalar values, this parameter must be set to zero.
 ;
-; Opt. Inputs :	
+; Opt. Inputs :
 ;
 ; Outputs     :	None.
 ;
@@ -52,9 +52,9 @@
 ;
 ; Keywords    :	RESULT: Receives the error messages (string array)
 ;                       if the keyword /NOERROR is set.
-;               
+;
 ;               NOERROR: Set to avoid error message (stopping)
-;                 
+;
 ;               MINVAL: Minimum value for the parameter. Checked
 ;                       agains MIN([parameter]).
 ;
@@ -66,17 +66,17 @@
 ;
 ; Restrictions:	None.
 ;
-; Side effects:	
+; Side effects:
 ;	If an error in the parameter is a message is printed
 ;	a RETALL issued
 ;
 ; Category    :	Utilities, Miscellaneous
 ;
-; Prev. Hist. :	
+; Prev. Hist. :
 ;       Taken from ZPARCHECK:
 ;	version 1  D. Lindler  Dec. 86
 ;	documentation updated.  M. Greason, May 1990.
-;       
+;
 ;
 ; Written     :	D. Lindler, GSFC/HRS, December 1986
 ;
@@ -88,8 +88,8 @@
 ;                 object name
 ;
 ; Version     :	Version 3, September 2022
-; 
-; $Id: 2022-09-23 14:23 CEST $
+;
+; $Id: 2022-09-23 14:26 CEST $
 ;-
 ;
 ;----------------------------------------------------------
@@ -97,14 +97,14 @@
 PRO prits_tools::check_type, parameter, types, error, error_message
   compile_opt static, idl2
   IF typename(types) NE 'STRING' THEN BEGIN
-     new_types = []
-     foreach type, types DO new_types = [new_types, prits_tools.typename_from_typecode(type)]
+    new_types = []
+    foreach type, types DO new_types = [new_types, prits_tools.typename_from_typecode(type)]
   END ELSE types = prits_tools.tnames_from_tnames(STRUPCASE(types))
   par_type = size(parameter, /tname)
   valid = WHERE(par_type EQ types, Ngood)
   error = ''
   IF where(par_type EQ types) EQ -1 THEN BEGIN
-     error = error_message
+    error = error_message
   ENDIF
 END
 
@@ -113,9 +113,9 @@ PRO prits_tools::check_ndims, parameter, valid_ndims, error, error_message
   par_ndim = size(parameter, /n_dimensions)
   error = ''
   IF (where(par_ndim EQ valid_ndims))[0] EQ -1 THEN BEGIN
-     error = error_message
+    error = error_message
   END
-END 
+END
 
 
 PRO prits_tools::check_range, parameter, min, max, error
@@ -123,10 +123,10 @@ PRO prits_tools::check_range, parameter, min, max, error
   IF n_elements(max) GT 1 THEN message, "MAXVAL keyword of PRITS_TOOLS::PARCHECK must be scalar"
   error = []
   IF n_elements(max) EQ 1 THEN BEGIN
-     IF (where(parameter GT max))[0] NE -1 THEN error = 'is larger than maximum value ' + trim(max)
+    IF (where(parameter GT max))[0] NE -1 THEN error = 'is larger than maximum value ' + trim(max)
   END
   IF n_elements(min) EQ 1 THEN BEGIN
-     IF (where(parameter LT min))[0] NE -1 THEN error = 'is smaller than minimum value ' + trim(min)
+    IF (where(parameter LT min))[0] NE -1 THEN error = 'is smaller than minimum value ' + trim(min)
   END
 END
 
@@ -140,16 +140,16 @@ FUNCTION prits_tools::tnames_from_tnames, typenames
   multiplicative = [numeric, 'COMPLEX', 'DCOMPLEX']
   new_typenames = []
   foreach typename, typenames DO BEGIN
-     CASE typename OF 
-        'UNSIGNED': add = unsigned
-        'SIGNED': add = signed
-        'INTEGERS': add = integers
-        'FLOATS': add = floats
-        'NUMERIC': add = numeric
-        'MULTIPLICATIVE': add = multiplicative
-        ELSE: add = typename
-     END
-     new_typenames = [new_typenames, add]
+    CASE typename OF
+      'UNSIGNED': add = unsigned
+      'SIGNED': add = signed
+      'INTEGERS': add = integers
+      'FLOATS': add = floats
+      'NUMERIC': add = numeric
+      'MULTIPLICATIVE': add = multiplicative
+      ELSE: add = typename
+    END
+    new_typenames = [new_typenames, add]
   END
   return, new_typenames
 END
@@ -158,95 +158,95 @@ END
 FUNCTION prits_tools::typename_from_typecode, typecode
   IF size(typecode, /tname) EQ 'STRING' THEN return, STRUPCASE(typecode)
   CASE typecode OF
-     0: return, 'UNDEFINED'
-     1: return, 'BYTE'
-     2: return, 'INT'
-     3: return, 'LONG'
-     4: return, 'FLOAT'
-     5: return, 'DOUBLE'
-     6: return, 'COMPLEX'
-     7: return, 'STRING'
-     8: return, 'STRUCT'
-     9: return, 'DCOMPLEX'
-     10: return, 'POINTER'
-     11: return, 'OBJREF'
-     12: return, 'UINT'
-     13: return, 'ULONG'
-     14: return, 'LONG64'
-     15: return, 'ULONG64'
+    0: return, 'UNDEFINED'
+    1: return, 'BYTE'
+    2: return, 'INT'
+    3: return, 'LONG'
+    4: return, 'FLOAT'
+    5: return, 'DOUBLE'
+    6: return, 'COMPLEX'
+    7: return, 'STRING'
+    8: return, 'STRUCT'
+    9: return, 'DCOMPLEX'
+    10: return, 'POINTER'
+    11: return, 'OBJREF'
+    12: return, 'UINT'
+    13: return, 'ULONG'
+    14: return, 'LONG64'
+    15: return, 'ULONG64'
 
   END
 END
 
 
 PRO prits_tools::parcheck, parameter, parnum, name,  types, valid_ndims, default=default, $
-                             maxval=maxval,minval=minval, $
-                             result=result
+  maxval=maxval,minval=minval, $
+  result=result
   compile_opt idl2, static
-  
+
   IF n_params() EQ 1 AND n_elements(default) NE 0 THEN BEGIN
-     IF n_elements(parameter) EQ 0 THEN parameter = default
-     return
+    IF n_elements(parameter) EQ 0 THEN parameter = default
+    return
   END
-  
+
   IF n_elements(parameter) EQ 0 THEN BEGIN
-     err = 'is undefined and no default has been specified'
-     GOTO, ABORT
+    err = 'is undefined and no default has been specified'
+    GOTO, ABORT
   ENDIF
-   
+
   IF N_params() LT 5 THEN BEGIN
-     on_error, 2
-     message, 'Use: PARCHECK, parameter, parnum, name, types, dimensions'
+    on_error, 2
+    message, 'Use: PARCHECK, parameter, parnum, name, types, dimensions'
   END
-  
+
   noerror = arg_present(result)
   result = ''
-  
+
   pt = prits_tools()
-  
+
   errors = []
   pt.check_ndims, parameter, valid_ndims, err, "has wrong number of dimensions"
   IF err NE '' THEN errors = [errors, err]
-   
+
   pt.check_type, parameter, types, err, "is an invalid data type"
   IF err NE '' THEN errors = [errors, err]
-    
+
   pt.check_range, parameter, minval, maxval, err
   IF err NE '' THEN errors = [errors, err]
-  
-  IF n_elements(errors) EQ 0 THEN return
-   
-ABORT:
-   help,calls=callers
-   caller=strupcase((str_sep(callers[1],' '))[0])
 
-   IF parnum NE 0 THEN result = 'Parameter ' + trim(parnum) + ' ('+name+')' $
-   else                result = 'Keyword ' + name + ' '
-   
-   result = [result + ' of routine ' + STRUPCASE(caller) + ' ' + errors]
-   
-   dimension_strings = trim(valid_ndims)
-   dimension_string = strjoin(dimension_strings, ', ')
-   result = [result,'Valid number of dimensions are: '+dimension_string]
-   
-   stype = ''
-   FOR i = 0, N_elements( types )-1 DO BEGIN
-      stype += pt.typename_from_typecode(types[i])
-      IF i LT N_elements( types )-1 THEN stype += ', '
-   END
-   
-   result = [result,'Valid types are: ' + stype]
-   
-   IF Keyword_SET(noerror) THEN RETURN
-   PRINT,''                     ; Blank line
-   FOR i=0,N_elements(result)-1 DO Print,"! " + result[i]
-   print
-   
-   on_error, 2
-   MESSAGE,"STOPPING, returning to checkpoint in " + caller + string([13b, 10b])
-   
+  IF n_elements(errors) EQ 0 THEN return
+
+  ABORT:
+  help,calls=callers
+  caller=strupcase((str_sep(callers[1],' '))[0])
+
+  IF parnum NE 0 THEN result = 'Parameter ' + trim(parnum) + ' ('+name+')' $
+  else                result = 'Keyword ' + name + ' '
+
+  result = [result + ' of routine ' + STRUPCASE(caller) + ' ' + errors]
+
+  dimension_strings = trim(valid_ndims)
+  dimension_string = strjoin(dimension_strings, ', ')
+  result = [result,'Valid number of dimensions are: '+dimension_string]
+
+  stype = ''
+  FOR i = 0, N_elements( types )-1 DO BEGIN
+    stype += pt.typename_from_typecode(types[i])
+    IF i LT N_elements( types )-1 THEN stype += ', '
+  END
+
+  result = [result,'Valid types are: ' + stype]
+
+  IF Keyword_SET(noerror) THEN RETURN
+  PRINT,''                     ; Blank line
+  FOR i=0,N_elements(result)-1 DO Print,"! " + result[i]
+  print
+
+  on_error, 2
+  MESSAGE,"STOPPING, returning to checkpoint in " + caller + string([13b, 10b])
+
 END
-   
+
 PRO prits_tools::parcheck_test
   compile_opt static
   prits_tools.parcheck,[5],2,"test",['BYTE'],[0, 5], result = result
@@ -254,8 +254,8 @@ PRO prits_tools::parcheck_test
 END
 
 IF getenv("USER") EQ "steinhh" THEN BEGIN
-   add_path, "$HOME/idl/solo-spice-ql", /expand
-   prits_tools.parcheck_test
+  add_path, "$HOME/idl/solo-spice-ql", /expand
+  prits_tools.parcheck_test
 END
 
 

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -289,18 +289,18 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
     otype = ''
     FOR i = 0, N_elements( structure_name )-1 DO BEGIN
       otype += structure_name[i]
-      IF i LT N_elements( types )-1 THEN stype += ', '
+      IF i LT N_elements( structure_name )-1 THEN otype += ', '
     ENDFOR
     result = [result,'Valid structure names are: ' + otype]
   ENDIF
 
   IF N_ELEMENTS(class_name) GT 0 THEN BEGIN
-    otype = ''
+    ctype = ''
     FOR i = 0, N_elements( class_name )-1 DO BEGIN
-      otype += class_name[i]
-      IF i LT N_elements( types )-1 THEN stype += ', '
+      ctype += class_name[i]
+      IF i LT N_elements( class_name )-1 THEN ctype += ', '
     ENDFOR
-    result = [result,'Valid object (class) names are: ' + otype]
+    result = [result,'Valid object (class) names are: ' + ctype]
   ENDIF
 
   IF Keyword_SET(noerror) THEN RETURN
@@ -338,33 +338,51 @@ PRO prits_tools::parcheck_test
   print, result, format='(a)'
   print,''
   print,'Test 6 should fail'
-  prits_tools.parcheck, st, 0, "test_06", 8, 0, result=result, structure_name='anotherstruct'
-  print, result, format='(a)'
-  print,''
-  print,'Test 5b should be ok'
-  stb = [st, st]
-  prits_tools.parcheck, stb, 0, "test_05b", 8, 1, result=result, structure_name='mystruct'
+  prits_tools.parcheck, st, 0, "test_06", 8, 0, result=result, structure_name=['anotherstruct','struc']
   print, result, format='(a)'
   print,''
   print,'Test 7 should be ok'
-  obj = obj_new('IDL_Container')
-  prits_tools.parcheck, obj, 0, "test_07", 11, 0, result=result, class_name='IDL_Container'
+  stb = [st, st]
+  prits_tools.parcheck, stb, 0, "test_07", 8, 1, result=result, structure_name='mystruct'
   print, result, format='(a)'
   print,''
-  print,'Test 8 should fail'
-  prits_tools.parcheck, obj, 0, "test_08", 11, 0, result=result, class_name='MyObject'
+  print,'Test 8 should be ok'
+  obj = obj_new('IDL_Container')
+  prits_tools.parcheck, obj, 0, "test_08", 11, 0, result=result, class_name=['IDL_Container','MyObject']
   print, result, format='(a)'
   print,''
   print,'Test 9 should fail'
-  prits_tools.parcheck, [5], 1, "test_09", ['numeric'], [0, 1], result=result, minval=10, maxval=20
+  prits_tools.parcheck, obj, 0, "test_09", 11, 0, result=result, class_name=['MyObject','AnotherObject']
+  print, result, format='(a)'
+;  print,''
+;  print,'Test 10 should be ok'
+  hash = HASH("one", 1.0, "blue", [255,0,0], "Pi", !DPI)
+;  prits_tools.parcheck, hash, 0, "test_10", 11, 1, result=result, class_name='hash'
+;  print, result, format='(a)'
+;  print,''
+;  print,'Test 11 should fail'
+;  prits_tools.parcheck, hash, 0, "test_11", 11, 0, result=result, class_name='list'
+;  print, result, format='(a)'
+  print,''
+  print,'Test 12 should be ok'
+  prits_tools.parcheck, hash, 0, "test_12", 11, 1, result=result
   print, result, format='(a)'
   print,''
-  print,'Test 10 should fail'
-  prits_tools.parcheck, indgen(20,20), 1, "test_10", ['integers'], [0, 1, 2], result=result, minval=10, maxval=20
+  print,'Test 13 should be ok'
+  list=LIST('one', 2.0, 3, 4l, PTR_NEW(5), {n:6}, COMPLEX(7,0))
+  prits_tools.parcheck, list, 0, "test_13", 11, 1, result=result, class_name='list'
   print, result, format='(a)'
   print,''
-  print,'Test 11 should be ok'
-  prits_tools.parcheck, [11,15,19], 1, "test_10", ['integers'], [0, 1, 2], result=result, minval=10, maxval=20
+  print,'Test 14 should fail'
+  prits_tools.parcheck, [5], 1, "test_14", ['numeric'], [0, 1], result=result, minval=10, maxval=20
+  print, result, format='(a)'
+  print,''
+  print,'Test 15 should fail'
+  prits_tools.parcheck, indgen(20,20), 2, "test_15", ['integers'], [0, 1, 2], result=result, minval=10, maxval=20
+  print, result, format='(a)'
+  print,''
+  print,'Test 16 should be ok'
+  prits_tools.parcheck, [11,15,19], 3, "test_16", ['integers'], [0, 1, 2], result=result, minval=10, maxval=20
   print, result, format='(a)'
 END
 

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -18,7 +18,7 @@
 ;                             maxval=maxval,minval=minval, object_name=object_name, $
 ;                             result=result
 ;
-;	EXAMPLE:
+;	EXAMPLE     :
 ;
 ;	IDL> parcheck, hdr, 2, 'FITS Image Header', 7, 1
 ;
@@ -28,8 +28,10 @@
 ;		"Parameter 2 (FITS Image Header) is undefined"
 ;		"Valid dimensions are 1"
 ;		"Valid types are string"
+;		
+; See prits_tools::parcheck_test for more examples.
 ;
-; Inputs      :
+; INPUTS      :
 ;	PARAMETER - Parameter passed to the routine.
 ;	PARNUM    - Integer parameter number.This information will be used
 ;             in a possible error message. If set to zero the parameter
@@ -107,7 +109,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-28 11:24 CEST $
+; $Id: 2022-09-28 11:36 CEST $
 ;-
 ;
 ;----------------------------------------------------------

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -88,7 +88,7 @@
 ;
 ; Common      :	None.
 ;
-; Restrictions:	
+; Restrictions:
 ; LIST, HASH, DICTIONARY and ORDEREDHASH alway have dimension 1, except if they are empty.
 ; A 1-dimensional array of those will also have dimension 1.
 ;
@@ -115,12 +115,12 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-29 10:38 CEST $
+; $Id: 2022-09-29 14:19 CEST $
 ;-
 ;
 ;----------------------------------------------------------
 
-PRO prits_tools::check_type, parameter, types, error, error_message, pt, $
+PRO prits_tools::check_type, parameter, types, error, pt, $
   structure_name=structure_name, class_name=class_name
   IF typename(types) NE 'STRING' THEN BEGIN
     new_types = []
@@ -131,38 +131,43 @@ PRO prits_tools::check_type, parameter, types, error, error_message, pt, $
   ENDELSE
   par_type = size(parameter, /tname)
   IF (where(par_type EQ types))[0] EQ -1 THEN BEGIN
-    error = error_message+par_type
+    error = "is an invalid data type: " + par_type
   ENDIF ELSE BEGIN
     error = ''
     IF par_type EQ 'STRUCT' && N_ELEMENTS(structure_name) GT 0 THEN BEGIN
       structure_name = STRUPCASE(structure_name)
       IF (where(typename(parameter[0]) EQ structure_name))[0] EQ -1 THEN BEGIN
-        error = 'is an invalid structure type: '+typename(parameter[0])
+        error = 'is an invalid structure type: ' + typename(parameter[0])
       ENDIF
     ENDIF
     IF par_type EQ 'OBJREF' && N_ELEMENTS(class_name) GT 0 THEN BEGIN
-      class_name = STRUPCASE(class_name)
-      par_typename = typename(parameter)
-      IF (where(par_typename EQ class_name))[0] EQ -1 THEN BEGIN
-        IF par_typename NE 'LIST' && par_typename NE 'HASH' && $
-          par_typename NE 'DICTIONARY' && par_typename NE 'ORDEREDHASH' THEN BEGIN
-          IF (where(typename(parameter[0]) EQ class_name))[0] EQ -1 THEN BEGIN
-            error = 'is an invalid object/class type: '+typename(parameter)
-          ENDIF
-        ENDIF ELSE BEGIN
-          error = 'is an invalid object/class type: '+typename(parameter)
-        ENDELSE
-      ENDIF
+      pt.check_class_name, parameter, error, class_name
     ENDIF
   ENDELSE
 END
 
 
-PRO prits_tools::check_ndims, parameter, valid_ndims, error, error_message
+PRO prits_tools::check_class_name, parameter, error, class_name
+  class_name = STRUPCASE(class_name)
+  par_typename = typename(parameter)
+  IF (where(par_typename EQ class_name))[0] EQ -1 THEN BEGIN
+    IF par_typename NE 'LIST' && par_typename NE 'HASH' && $
+      par_typename NE 'DICTIONARY' && par_typename NE 'ORDEREDHASH' THEN BEGIN
+      IF (where(typename(parameter[0]) EQ class_name))[0] EQ -1 THEN BEGIN
+        error = 'is an invalid object/class type: ' + typename(parameter)
+      ENDIF
+    ENDIF ELSE BEGIN
+      error = 'is an invalid object/class type: ' + typename(parameter)
+    ENDELSE
+  ENDIF
+END
+
+
+PRO prits_tools::check_ndims, parameter, valid_ndims, error
   par_ndim = size(parameter, /n_dimensions)
   IF size(parameter, /type) EQ 8 && N_ELEMENTS(parameter) EQ 1 THEN par_ndim=0
   IF (where(par_ndim EQ valid_ndims))[0] EQ -1 THEN BEGIN
-    error = error_message+trim(par_ndim)
+    error = "has wrong number of dimensions: " + trim(par_ndim)
   ENDIF ELSE BEGIN
     error = ''
   ENDELSE
@@ -264,10 +269,10 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
     message, 'Use: PARCHECK, parameter, parnum, name, types, dimensions'
   ENDIF
 
-  pt.check_ndims, parameter, valid_ndims, err, "has wrong number of dimensions: "
+  pt.check_ndims, parameter, valid_ndims, err
   IF err NE '' THEN errors = [errors, err]
 
-  pt.check_type, parameter, types, err, "is an invalid data type: ", pt, $
+  pt.check_type, parameter, types, err, pt, $
     structure_name=structure_name, class_name=class_name
   IF err NE '' THEN errors = [errors, err]
 

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -69,10 +69,10 @@
 ;                       and procedure returns to caller without stopping.
 ;
 ;               MINVAL: Minimum value for the parameter. Checked
-;                       agains MIN([parameter]).
+;                       against MIN([parameter]).
 ;
 ;               MAXVAL: Maximum value for the parameter. Checked
-;                       agains MAX([parameter]).
+;                       against MAX([parameter]).
 ;
 ;               STRUCTURE_NAME: string, scalar or vector. If the input parameter
 ;                         is of type 8 (STRUCT), the name of the structure
@@ -121,7 +121,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-29 15:08 CEST $
+; $Id: 2022-09-29 15:15 CEST $
 ;-
 ;
 ;----------------------------------------------------------

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -116,11 +116,12 @@
 ;               Version 2, Stein Vidar Haugan, UiO, October 1995
 ;               Version 3, Martin Wiesmann, UiO, September 2022
 ;                 Generell overhaul, bugfixing and introduced check for
-;                 object name, improved documentation
+;                 object name, i.e. new keywords STRUCTURE_NAME, CLASS_NAME and DISALLOW_SUBCLASS,
+;                 improved documentation
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-29 15:03 CEST $
+; $Id: 2022-09-29 15:08 CEST $
 ;-
 ;
 ;----------------------------------------------------------

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -8,7 +8,7 @@
 ; Explanation :
 ;	This routine checks whether a parameter fulfills some criteria. It checks the data type
 ;	and the number of dimensions. Optionally, it can also check for minimum and/or maximum
-;	allowed values, or for object and structure names.
+;	allowed values, or for object/class and structure names.
 ;	If the parameter is undefined, then the DEFAULT value is returned if provided.
 ;	If one of the tests fails a message is printed and a RETALL issued.
 ;	These consequences can be suppressed by supplying the RESULT keyword.
@@ -28,7 +28,7 @@
 ;		"Parameter 2 (FITS Image Header) is undefined"
 ;		"Valid dimensions are 1"
 ;		"Valid types are string"
-;		
+;
 ; See prits_tools::parcheck_test for more examples.
 ;
 ; INPUTS      :
@@ -79,8 +79,8 @@
 ;                         is checked against STRUCTURE_NAME.
 ;
 ;               CLASS_NAME: string, scalar or vector. If the input parameter
-;                         is of type 11 (OBJREF), the name of the object (class)
-;                         is checked against STRUCTURE_NAME.
+;                         is of type 11 (OBJREF), the name of the object/class
+;                         is checked against CLASS_NAME.
 ;
 ;               DEFAULT: If parameter is undefined, then DEFAULT will be returned.
 ;
@@ -88,7 +88,9 @@
 ;
 ; Common      :	None.
 ;
-; Restrictions:	None.
+; Restrictions:	
+; LIST, HASH, DICTIONARY and ORDEREDHASH alway have dimension 1, except if they are empty.
+; A 1-dimensional array of those will also have dimension 1.
 ;
 ; Side effects:
 ;	If an error in the parameter is found, a message is printed and
@@ -113,7 +115,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-28 11:36 CEST $
+; $Id: 2022-09-29 10:38 CEST $
 ;-
 ;
 ;----------------------------------------------------------
@@ -140,8 +142,16 @@ PRO prits_tools::check_type, parameter, types, error, error_message, pt, $
     ENDIF
     IF par_type EQ 'OBJREF' && N_ELEMENTS(class_name) GT 0 THEN BEGIN
       class_name = STRUPCASE(class_name)
-      IF (where(typename(parameter[0]) EQ class_name))[0] EQ -1 THEN BEGIN
-        error = 'is an invalid object (class) type: '+typename(parameter[0])
+      par_typename = typename(parameter)
+      IF (where(par_typename EQ class_name))[0] EQ -1 THEN BEGIN
+        IF par_typename NE 'LIST' && par_typename NE 'HASH' && $
+          par_typename NE 'DICTIONARY' && par_typename NE 'ORDEREDHASH' THEN BEGIN
+          IF (where(typename(parameter[0]) EQ class_name))[0] EQ -1 THEN BEGIN
+            error = 'is an invalid object/class type: '+typename(parameter)
+          ENDIF
+        ENDIF ELSE BEGIN
+          error = 'is an invalid object/class type: '+typename(parameter)
+        ENDELSE
       ENDIF
     ENDIF
   ENDELSE
@@ -300,7 +310,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
       ctype += class_name[i]
       IF i LT N_elements( class_name )-1 THEN ctype += ', '
     ENDFOR
-    result = [result,'Valid object (class) names are: ' + ctype]
+    result = [result,'Valid object/class names are: ' + ctype]
   ENDIF
 
   IF Keyword_SET(noerror) THEN RETURN
@@ -346,31 +356,51 @@ PRO prits_tools::parcheck_test
   prits_tools.parcheck, stb, 0, "test_07", 8, 1, result=result, structure_name='mystruct'
   print, result, format='(a)'
   print,''
-  print,'Test 8 should be ok'
+  print,'Test 8.1 should be ok'
   obj = obj_new('IDL_Container')
-  prits_tools.parcheck, obj, 0, "test_08", 11, 0, result=result, class_name=['IDL_Container','MyObject']
+  prits_tools.parcheck, obj, 0, "test_08.1", 11, 0, result=result, class_name=['IDL_Container','MyObject']
+  print, result, format='(a)'
+  print,''
+  print,'Test 8.2 should fail'
+  prits_tools.parcheck, obj, 0, "test_08.2", 11, 1, result=result, class_name=['IDL_Container','MyObject']
+  print, result, format='(a)'
+  print,''
+  print,'Test 8.3 should be ok'
+  prits_tools.parcheck, [obj, obj], 0, "test_08.3", 11, 1, result=result, class_name='IDL_Container'
+  print, result, format='(a)'
+  print,''
+  print,'Test 8.4 should fail'
+  prits_tools.parcheck, [obj, obj], 0, "test_08.4", 11, 0, result=result, class_name='IDL_Container'
   print, result, format='(a)'
   print,''
   print,'Test 9 should fail'
   prits_tools.parcheck, obj, 0, "test_09", 11, 0, result=result, class_name=['MyObject','AnotherObject']
   print, result, format='(a)'
-;  print,''
-;  print,'Test 10 should be ok'
-  hash = HASH("one", 1.0, "blue", [255,0,0], "Pi", !DPI)
-;  prits_tools.parcheck, hash, 0, "test_10", 11, 1, result=result, class_name='hash'
-;  print, result, format='(a)'
-;  print,''
-;  print,'Test 11 should fail'
-;  prits_tools.parcheck, hash, 0, "test_11", 11, 0, result=result, class_name='list'
-;  print, result, format='(a)'
   print,''
-  print,'Test 12 should be ok'
-  prits_tools.parcheck, hash, 0, "test_12", 11, 1, result=result
+  print,'Test 10 should be ok'
+  hash = HASH("one", 1.0, "blue", [255,0,0], "Pi", !DPI)
+  prits_tools.parcheck, hash, 0, "test_10", 11, 1, result=result, class_name='hash'
   print, result, format='(a)'
   print,''
-  print,'Test 13 should be ok'
+  print,'Test 11 should fail'
+  prits_tools.parcheck, hash, 0, "test_11", 11, 0, result=result, class_name='list'
+  print, result, format='(a)'
+  print,''
+  print,'Test 12.1 should be ok'
+  prits_tools.parcheck, hash, 0, "test_12.1", 11, 1, result=result
+  print, result, format='(a)'
+  print,''
+  print,'Test 12.2 should be ok'
+  prits_tools.parcheck, [hash, hash], 0, "test_12.2", 11, 1, result=result, class_name='hash'
+  print, result, format='(a)'
+  print,''
+  print,'Test 13.1 should be ok'
   list=LIST('one', 2.0, 3, 4l, PTR_NEW(5), {n:6}, COMPLEX(7,0))
-  prits_tools.parcheck, list, 0, "test_13", 11, 1, result=result, class_name='list'
+  prits_tools.parcheck, list, 0, "test_13.1", 11, 1, result=result, class_name='list'
+  print, result, format='(a)'
+  print,''
+  print,'Test 13.2 should be ok'
+  prits_tools.parcheck, [list, list], 0, "test_13.2", 11, 1, result=result, class_name='list'
   print, result, format='(a)'
   print,''
   print,'Test 14 should fail'

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -121,7 +121,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-30 10:58 CEST $
+; $Id: 2022-09-30 11:37 CEST $
 ;-
 ;
 ;----------------------------------------------------------
@@ -384,6 +384,7 @@ PRO prits_tools::parcheck_test
   print,'Test 5.3 should be ok'
   prits_tools.parcheck, [11,15,19], 3, "test_05.3", ['integers'], [0, 1, 2], result=result, minval=10, maxval=20
   print, result, format='(a)'
+  
   print,''
   print,'Test 5.4 should fail'
   prits_tools.parcheck, [11,15,19], 3, "test_05.4", ['integers'], [0, 1, 2], result=result, minval=[10,11], maxval=20
@@ -412,9 +413,9 @@ PRO prits_tools::parcheck_test
   print, result, format='(a)'
   print,''
   print,'Test 8 should be ok'
-  stb = [st, st]
-  prits_tools.parcheck, stb, 0, "test_08", 8, 1, result=result, structure_name='mystruct'
+  prits_tools.parcheck, [st, st], 0, "test_08", 8, 1, result=result, structure_name='mystruct'
   print, result, format='(a)'
+  
   print,''
   print,'Test 9.1 should be ok'
   obj = obj_new('IDL_Container')
@@ -436,6 +437,7 @@ PRO prits_tools::parcheck_test
   print,'Test 9.5 should fail'
   prits_tools.parcheck, obj, 0, "test_09.5", 11, 0, result=result, class_name=['MyObject','AnotherObject']
   print, result, format='(a)'
+  
   print,''
   print,'Test 10 should be ok'
   hash = HASH("one", 1.0, "blue", [255,0,0], "Pi", !DPI)
@@ -453,6 +455,7 @@ PRO prits_tools::parcheck_test
   print,'Test 12.2 should be ok'
   prits_tools.parcheck, [hash, hash], 0, "test_12.2", 11, 1, result=result, class_name='hash'
   print, result, format='(a)'
+  
   print,''
   print,'Test 13.1 should be ok'
   list = LIST('one', 2.0, 3, 4l, PTR_NEW(5), {n:6}, COMPLEX(7,0))
@@ -462,6 +465,7 @@ PRO prits_tools::parcheck_test
   print,'Test 13.2 should be ok'
   prits_tools.parcheck, [list, list], 0, "test_13.2", 11, 1, result=result, class_name='list'
   print, result, format='(a)'
+  
   print,''
   a = obj_new('idlitvisaxis')
   print,'Test 14.1 should be ok'

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -121,7 +121,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-30 11:37 CEST $
+; $Id: 2022-09-30 11:44 CEST $
 ;-
 ;
 ;----------------------------------------------------------
@@ -341,7 +341,10 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
       ctype += class_name[i]
       IF i LT N_elements( class_name )-1 THEN ctype += ', '
     ENDFOR
-    result = [result,'Valid object/class names are: ' + ctype]
+    result_temp = 'Valid object/class names are: ' + ctype + ' (subclasses '
+    IF keyword_set(disallow_subclasses) THEN result_temp += 'NOT '
+    result_temp += 'allowed)'
+    result = [result, result_temp]
   ENDIF
 
   IF Keyword_SET(noerror) THEN RETURN
@@ -353,6 +356,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
   MESSAGE,"STOPPING, returning to checkpoint in " + caller + string([13b, 10b])
 
 END
+
 
 PRO prits_tools::parcheck_test
   compile_opt static
@@ -484,6 +488,7 @@ PRO prits_tools::parcheck_test
   prits_tools.parcheck, [a, a], 0, "test_14.4", 11, [0, 1], result=result, class_name='idlitvisualization'
   print, result, format='(a)'
 END
+
 
 IF getenv("USER") EQ "steinhh" || getenv("USER") EQ "mawiesma" THEN BEGIN
   IF getenv("USER") EQ "steinhh" THEN add_path, "$HOME/idl/solo-spice-ql", /expand

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -119,7 +119,9 @@ PRO prits_tools::check_type, parameter, types, error, error_message, pt, object_
     new_types = []
     foreach type, types DO new_types = [new_types, pt.typename_from_typecode(type, pt)]
     types = new_types
-  END ELSE types = pt.tnames_from_tnames(STRUPCASE(types))
+  ENDIF ELSE BEGIN
+    types = pt.tnames_from_tnames(STRUPCASE(types))
+  ENDELSE
   par_type = size(parameter, /tname)
   IF (where(par_type EQ types))[0] EQ -1 THEN BEGIN
     error = error_message+par_type
@@ -140,7 +142,9 @@ PRO prits_tools::check_ndims, parameter, valid_ndims, error, error_message
   IF size(parameter, /type) EQ 8 && N_ELEMENTS(parameter) EQ 1 THEN par_ndim=0
   IF (where(par_ndim EQ valid_ndims))[0] EQ -1 THEN BEGIN
     error = error_message+trim(par_ndim)
-  ENDIF ELSE error = ''
+  ENDIF ELSE BEGIN
+    error = ''
+  ENDELSE
 END
 
 
@@ -150,14 +154,14 @@ PRO prits_tools::check_range, parameter, min, max, error
   error = ''
   IF n_elements(min) EQ 1 THEN BEGIN
     IF (where(parameter LT min))[0] NE -1 THEN error = 'is smaller than minimum value ' + trim(min)
-  END
+  ENDIF
   IF n_elements(max) EQ 1 THEN BEGIN
     IF (where(parameter GT max))[0] NE -1 THEN BEGIN
       error_temp = 'is larger than maximum value ' + trim(max)
       IF error NE '' THEN error = [error, error_temp] $
       ELSE error = error_temp
     ENDIF
-  END
+  ENDIF
 END
 
 
@@ -178,9 +182,9 @@ FUNCTION prits_tools::tnames_from_tnames, typenames
       'NUMERIC': add = numeric
       'MULTIPLICATIVE': add = multiplicative
       ELSE: add = typename
-    END
+    ENDCASE
     new_typenames = [new_typenames, add]
-  END
+  ENDFOREACH
   return, new_typenames
 END
 
@@ -204,8 +208,8 @@ FUNCTION prits_tools::typename_from_typecode, typecode, pt
     13: return, 'ULONG'
     14: return, 'LONG64'
     15: return, 'ULONG64'
-    else: message, 'TYPE CODE must be GE 0 and LE 15'
-  END
+    ELSE: message, 'TYPE CODE must be GE 0 and LE 15'
+  ENDCASE
 END
 
 
@@ -222,7 +226,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
   IF n_params() EQ 1 AND n_elements(default) NE 0 THEN BEGIN
     IF n_elements(parameter) EQ 0 THEN parameter = default
     return
-  END
+  ENDIF
 
   IF n_elements(parameter) EQ 0 THEN BEGIN
     IF n_elements(default) NE 0 THEN BEGIN
@@ -237,7 +241,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
   IF N_params() LT 5 THEN BEGIN
     on_error, 2
     message, 'Use: PARCHECK, parameter, parnum, name, types, dimensions'
-  END
+  ENDIF
 
   pt.check_ndims, parameter, valid_ndims, err, "has wrong number of dimensions: "
   IF err NE '' THEN errors = [errors, err]
@@ -255,7 +259,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
   caller=strupcase((str_sep(callers[1],' '))[0])
 
   IF parnum NE 0 THEN result = 'Parameter ' + trim(parnum) + ' ('+name+')' $
-  else                result = 'Keyword ' + name + ' '
+  ELSE                result = 'Keyword ' + name + ' '
   result = [result + ' of routine ' + STRUPCASE(caller) + ' ' + errors]
 
   dimension_strings = trim(valid_ndims)
@@ -266,7 +270,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
   FOR i = 0, N_elements( types )-1 DO BEGIN
     stype += pt.typename_from_typecode(types[i], pt)
     IF i LT N_elements( types )-1 THEN stype += ', '
-  END
+  ENDFOR
   result = [result,'Valid types are: ' + stype]
 
   IF N_ELEMENTS(object_name) GT 0 THEN BEGIN
@@ -274,7 +278,7 @@ PRO prits_tools::parcheck, parameter, parnum, name, types, valid_ndims, default=
     FOR i = 0, N_elements( object_name )-1 DO BEGIN
       otype += object_name[i]
       IF i LT N_elements( types )-1 THEN stype += ', '
-    END
+    ENDFOR
     result = [result,'Valid object/structure names are: ' + otype]
   ENDIF
 
@@ -346,6 +350,6 @@ END
 IF getenv("USER") EQ "steinhh" || getenv("USER") EQ "mawiesma" THEN BEGIN
   IF getenv("USER") EQ "steinhh" THEN add_path, "$HOME/idl/solo-spice-ql", /expand
   prits_tools.parcheck_test
-END
+ENDIF
 
 END

--- a/prits-tools/prits_tools__parcheck.pro
+++ b/prits-tools/prits_tools__parcheck.pro
@@ -98,8 +98,8 @@
 ; A 1-dimensional array of those will also have dimension 1.
 ;
 ; Side effects:
-;	If an error in the parameter is found, a message is printed and
-;	a RETALL issued
+;	If an error in the parameter is found, a message is printed and a RETALL issued,
+;	except if the keyword RESULT is present.
 ;
 ; Category    :	Utilities, Miscellaneous
 ;
@@ -121,7 +121,7 @@
 ;
 ; Version     :	Version 3, September 2022
 ;
-; $Id: 2022-09-30 10:57 CEST $
+; $Id: 2022-09-30 10:58 CEST $
 ;-
 ;
 ;----------------------------------------------------------


### PR DESCRIPTION
- New keyword 'STRUCTURE_NAME', checks whether a structure is of the correct type
- New keyword 'OBJECT_NAME', checks whether an objectis of the correct type, or a subclass of the given class
- New keyword 'DISALLOW_SUBCLASS', if set subclasses of CLASS_NAME are not allowed
- Includes now prits_tools::tnames_from_tnames when checking parameter type
- Fixed some bugs
- Improved documentation